### PR TITLE
50 implement tool to find all missing data objects from legacy projects

### DIFF
--- a/nmdc_automation/nmdc_common/client.py
+++ b/nmdc_automation/nmdc_common/client.py
@@ -77,7 +77,7 @@ class NmdcApi:
             }
             url = self.base_url + "nmdcschema/" + workflow_activity_set
             response = requests.get(url, params=params, headers=self.headers)
-            logger.info(response.url)
+            logger.debug(response.url)
             response.raise_for_status()
             workflow_activity_record = response.json()["resources"]
             return workflow_activity_record

--- a/nmdc_automation/re_iding/db_utils.py
+++ b/nmdc_automation/re_iding/db_utils.py
@@ -12,8 +12,28 @@ from nmdc_schema.nmdc import Database, DataObject
 OMICS_PROCESSING_SET = "omics_processing_set"
 DATA_OBJECT_SET = "data_object_set"
 READS_QC_SET = "read_qc_analysis_activity_set"
+READS_BASED_TAXONOMY_ANALYSIS_ACTIVITY_SET = "read_based_taxonomy_analysis_activity_set"
 METAGENOME_ASSEMBLY_SET = "metagenome_assembly_set"
+METAGENOME_ANNOTATION_ACTIVITY_SET = "metagenome_annotation_activity_set"
+METAGENOME_SEQUENCING_ACTIVITY_SET = "metagenome_sequencing_activity_set"
+MAGS_ACTIVITY_SET = "mags_activity_set"
 METATRANSCRIPTOME_ACTIVITY_SET = "metatranscriptome_activity_set"
+METAPROTEOMICS_ANALYSIS_ACTIVITY_SET = "metaproteomics_analysis_activity_set"
+METABOLOMICS_ANALYSIS_ACTIVITY_SET = "metabolomics_analysis_activity_set"
+NOM_ANALYSIS_ACTIVITY_SET= "nom_analysis_activity_set"
+
+ANALYSIS_ACTIVITIES = [
+    READS_QC_SET,
+    READS_BASED_TAXONOMY_ANALYSIS_ACTIVITY_SET,
+    METAGENOME_ANNOTATION_ACTIVITY_SET,
+    METAGENOME_SEQUENCING_ACTIVITY_SET,
+    METAGENOME_ASSEMBLY_SET,
+    MAGS_ACTIVITY_SET,
+    METATRANSCRIPTOME_ACTIVITY_SET,
+    METAPROTEOMICS_ANALYSIS_ACTIVITY_SET,
+    METABOLOMICS_ANALYSIS_ACTIVITY_SET,
+    NOM_ANALYSIS_ACTIVITY_SET
+]
 
 
 


### PR DESCRIPTION
This PR provides a new command-line tool `orphan-data-objects`
- find all DataObject ID's from all workflow `has_input` / `has_output` slots for a Study
- Search each ID against the data_objects_set collection of the NMDC database
- Look for "orphan" DataObject ID's (not in the DB) in an extracted data file pulled from all `data_objects.json` files that could be found on the filesystem
- Write JSON of any DataObject(s) that can be recovered from the Data Objects file
- Write a log file detailing what was found / not found

Results:

https://drive.google.com/drive/folders/1HmadG7Ts6qqLBJX0OCzkF2qDCpBVmgs5?usp=drive_link