### PR TITLE
Fix - assign correct slot `gold_study_identifiers` if not already pop…

### DIFF
--- a/nmdc_automation/jgi_file_staging/jgi_file_metadata.py
+++ b/nmdc_automation/jgi_file_staging/jgi_file_metadata.py
@@ -11,8 +11,8 @@ import argparse
 from typing import List
 from pydantic import ValidationError
 
-from mongo import get_mongo_db
-from models import Sample
+from .mongo import get_mongo_db
+from .models import Sample
 
 logging.basicConfig(
     filename="file_staging.log",

--- a/nmdc_automation/re_iding/scripts/re_id_tool.py
+++ b/nmdc_automation/re_iding/scripts/re_id_tool.py
@@ -929,11 +929,11 @@ def _update_study_record(study_record: dict, new_study_id: str, db_client: Datab
 
     # Copy the legacy ID to gold_study_identifiers if it is not already there
     if legacy_study_id.startswith("gold:"):
-        gold_ids = study_record.get("gold_sequencing_project_identifiers", [])
+        gold_ids = study_record.get("gold_study_identifiers", [])
         if legacy_study_id not in gold_ids:
             gold_ids.append(legacy_study_id)
-            study_record["gold_sequencing_project_identifiers"] = gold_ids
-            logging.info(f"Added legacy study ID to gold_sequencing_project_identifiers: {legacy_study_id}")
+            study_record["gold_study_identifiers"] = gold_ids
+            logging.info(f"Added legacy study ID to gold_study_identifiers: {legacy_study_id}")
 
     if no_update:
         logging.info(f"Skipping database update")

--- a/tests/test_jgi_file_staging/test_file_metadata.py
+++ b/tests/test_jgi_file_staging/test_file_metadata.py
@@ -1,18 +1,14 @@
-import mongomock
 import pandas as pd
 from pathlib import Path
 import pytest
-
-from nmdc_automation.jgi_file_staging.models import Sample
 
 from nmdc_automation.jgi_file_staging.jgi_file_metadata import (
     get_access_token,
     check_access_token,
     get_sequence_id,
     get_analysis_projects_from_proposal_id,
-    insert_samples_into_mongodb,
 )
-from nmdc_automation.jgi_file_staging.mongo import get_mongo_db
+
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
 


### PR DESCRIPTION
Fixes a bug where `update-study` was assigning a slot `gold_sequencing_project_identifiers` at the Study level, which is incorrect.  Fixed to assign to `gold_study_identifiers` if not already there