### PR TITLE
125 issues with biosample re id logic

### DIFF
--- a/nmdc_automation/re_iding/base.py
+++ b/nmdc_automation/re_iding/base.py
@@ -635,6 +635,8 @@ def _get_biosample_legacy_id(biosample: nmdc.Biosample) -> str:
         return biosample.gold_biosample_identifiers[0]
     elif biosample.emsl_biosample_identifiers:
         return biosample.emsl_biosample_identifiers[0]
+    elif biosample.igsn_biosample_identifiers:
+        return biosample.igsn_biosample_identifiers[0]
     else:
         return biosample.id
 

--- a/nmdc_automation/re_iding/base.py
+++ b/nmdc_automation/re_iding/base.py
@@ -594,7 +594,7 @@ def compare_models(model, updated_model)-> dict:
     diff = {}
     for key in model_dict.keys():
         if model_dict[key] != updated_model_dict[key]:
-            diff[key] = (model_dict[key], updated_model_dict[key])
+            diff[key] = updated_model_dict[key]
     return diff
 
 

--- a/nmdc_automation/re_iding/base.py
+++ b/nmdc_automation/re_iding/base.py
@@ -618,7 +618,7 @@ def update_biosample(biosample: nmdc.Biosample, nmdc_study_id: str, api_client, 
     return updated_biosample
 
 
-def _get_new_biosample_id(biosample, api_client, identifiers_map):
+def _get_new_biosample_id(biosample, api_client, identifiers_map) -> str:
     if identifiers_map and ("biosample_set", biosample.id) in identifiers_map:
         new_biosample_id = identifiers_map[("biosample_set", biosample.id)]
         logging.info(f"Using new biosample ID from identifiers_map: {new_biosample_id}")

--- a/nmdc_automation/re_iding/scripts/re_id_tool.py
+++ b/nmdc_automation/re_iding/scripts/re_id_tool.py
@@ -218,6 +218,8 @@ def update_study(ctx, legacy_study_id, nmdc_study_id,  mongo_uri, identifiers_fi
         _log_updates(updates)
     else:
         # Update the records in the database
+        logging.info(f"Updating {len(updates)} collections - Updates:")
+        _log_updates(updates)
         with session.start_transaction():
             try:
                 for collection_name, record_updates in updates.items():

--- a/nmdc_automation/re_iding/tests/conftest.py
+++ b/nmdc_automation/re_iding/tests/conftest.py
@@ -22,3 +22,10 @@ def data_object_record():
                 "id": "nmdc:7bf778baef033d36f118f8591256d6ef",
                 "file_size_bytes": 2571324879
             }
+
+
+@pytest.fixture
+def igsn_biosample_record():
+    """Return a dict of a test IGSN Biosample instance"""
+    with open(TEST_DATA_DIR / "igsn_biosample_record.json", "r") as f:
+        return json.load(f)

--- a/nmdc_automation/re_iding/tests/test_data/igsn_biosample_record.json
+++ b/nmdc_automation/re_iding/tests/test_data/igsn_biosample_record.json
@@ -1,0 +1,53 @@
+{
+  "name": "Soil microbial communities from the East River watershed near Crested Butte, Colorado, United States - ER_134",
+  "description": "Soil microbial communities from the East River watershed near Crested Butte, Colorado, United States",
+  "lat_lon": {
+    "has_raw_value": "38.92028116 -106.9489189",
+    "latitude": 38.92028116,
+    "longitude": -106.9489189
+  },
+  "env_broad_scale": {
+    "has_raw_value": "ENVO:00000108",
+    "term": {
+      "id": "ENVO:00000108"
+    }
+  },
+  "env_local_scale": {
+    "has_raw_value": "ENVO:00000292",
+    "term": {
+      "id": "ENVO:00000292"
+    }
+  },
+  "env_medium": {
+    "has_raw_value": "ENVO:00005802",
+    "term": {
+      "id": "ENVO:00005802"
+    }
+  },
+  "type": "nmdc:Biosample",
+  "ecosystem": "Environmental",
+  "ecosystem_category": "Terrestrial",
+  "ecosystem_type": "Soil",
+  "ecosystem_subtype": "Unclassified",
+  "specific_ecosystem": "Unclassified",
+  "depth": {
+    "has_numeric_value": 5
+  },
+  "ncbi_taxonomy_name": "soil metagenome",
+  "community": "microbial communities",
+  "location": "The East River watershed near Crested Butte, Colorado, USA",
+  "habitat": "soil",
+  "sample_collection_site": "soil",
+  "id": "igsn:IEWFS000A",
+  "collection_date": {
+    "has_raw_value": "2017-05-09"
+  },
+  "geo_loc_name": {
+    "has_raw_value": "USA: Colorado"
+  },
+  "part_of": [
+    "gold:Gs0135149"
+  ],
+  "samp_name": "igsn:IEWFS000A",
+  "gold_biosample_identifiers": []
+}

--- a/nmdc_automation/re_iding/tests/test_re_iding_base.py
+++ b/nmdc_automation/re_iding/tests/test_re_iding_base.py
@@ -72,3 +72,21 @@ def test_update_biosample_igsn_biosample_record_id_set_correctly_no_id_map(igsn_
     assert updated_biosample.part_of == [exp_study_id]
     assert updated_biosample.igsn_biosample_identifiers == [orig_biosample_id]
 
+def test_compare_models_igsn_biosample_updates(igsn_biosample_record, mocker):
+    """
+    Test that we can compare a Biosample with an IGSN Biosample record and update it.
+    """
+    exp_biosample_id = "nmdc:bsm-1234-abcd12345"
+    mock_api = mocker.Mock(spec=NmdcRuntimeApi)
+    mock_api.minter.return_value = exp_biosample_id
+    exp_study_id = "nmdc:sty-1234-abcd12345"
+
+    orig_biosample_id = igsn_biosample_record["id"]
+    orig_study_id = igsn_biosample_record["part_of"][0]
+
+    biosample = Biosample(**igsn_biosample_record)
+    updated_biosample = update_biosample(biosample, exp_study_id, mock_api)
+
+    changes = compare_models(biosample, updated_biosample)
+    assert changes["id"] == (orig_biosample_id, exp_biosample_id)
+    assert changes["part_of"] == ([orig_study_id], [exp_study_id])

--- a/nmdc_automation/re_iding/tests/test_re_iding_base.py
+++ b/nmdc_automation/re_iding/tests/test_re_iding_base.py
@@ -88,5 +88,6 @@ def test_compare_models_igsn_biosample_updates(igsn_biosample_record, mocker):
     updated_biosample = update_biosample(biosample, exp_study_id, mock_api)
 
     changes = compare_models(biosample, updated_biosample)
-    assert changes["id"] == (orig_biosample_id, exp_biosample_id)
-    assert changes["part_of"] == ([orig_study_id], [exp_study_id])
+    assert changes["id"] == exp_biosample_id
+    assert changes["part_of"] == [exp_study_id]
+    assert changes["igsn_biosample_identifiers"] == [orig_biosample_id]

--- a/nmdc_automation/re_iding/tests/test_re_iding_base.py
+++ b/nmdc_automation/re_iding/tests/test_re_iding_base.py
@@ -5,7 +5,12 @@ import pytest_mock
 from nmdc_automation.api import NmdcRuntimeApi
 from nmdc_schema.nmdc import Database as NmdcDatabase
 from nmdc_schema.nmdc import DataObject as NmdcDataObject
-from nmdc_automation.re_iding.base import ReIdTool
+from nmdc_schema.nmdc import Biosample
+from nmdc_automation.re_iding.base import (
+    ReIdTool,
+    update_biosample,
+    compare_models,
+)
 
 
 TEST_DATAFILE_DIR = "./test_data/results"
@@ -47,3 +52,23 @@ def test_make_new_data_object(data_object_record, mocker):
     assert isinstance(new_do, NmdcDataObject)
     assert new_do.id == exp_do_id
     assert new_do.url == exp_url
+
+def test_update_biosample_igsn_biosample_record_id_set_correctly_no_id_map(igsn_biosample_record, mocker):
+    """
+    Test that we can update a Biosample with an IGSN Biosample record with no identifiers_map provided.
+    """
+    exp_biosample_id = "nmdc:bsm-1234-abcd12345"
+    mock_api = mocker.Mock(spec=NmdcRuntimeApi)
+    mock_api.minter.return_value = exp_biosample_id
+    exp_study_id = "nmdc:sty-1234-abcd12345"
+
+    orig_biosample_id = igsn_biosample_record["id"]
+
+    biosample = Biosample(**igsn_biosample_record)
+    updated_biosample = update_biosample(biosample, exp_study_id, mock_api)
+
+    assert isinstance(updated_biosample, Biosample)
+    assert updated_biosample.id == exp_biosample_id
+    assert updated_biosample.part_of == [exp_study_id]
+    assert updated_biosample.igsn_biosample_identifiers == [orig_biosample_id]
+


### PR DESCRIPTION
This PR provides a fix for the issue we saw with values such as biosample.id being updated with an array with both old and new IDs, rather than being replaced.

The `compare_models` function compares 2 models as dicts and returns the differences - I was passing these into pymongo.update_one.  The root problem was that the diffs where {"field_name": (old_value, new_value)} which will update the record to having both values.