### PR TITLE
136 update study does not set data objectwas generated by for metabolomics and nom activity has output

### DIFF
--- a/nmdc_automation/re_iding/base.py
+++ b/nmdc_automation/re_iding/base.py
@@ -842,3 +842,158 @@ def update_nom_analysis_activity(nom_analysis_activity: nmdc.NomAnalysisActivity
     updated_nom_analysis_activity.has_output = nmdc_output_data_object_ids
 
     return updated_nom_analysis_activity
+
+
+def get_updates_for_metabolomics_or_nom(omics_processing, updated_omics_processing, api_client, db_client,
+                                        identifiers_map, updated_record_identifiers, updates):
+    """
+    Update Metabolomics or NOM Analysis Activity records and their associated data objects.
+    Returns updated_omics_processing, updated_record_identifiers, and updates dictionaries.
+    """
+    # If either the omics_processing or updated_omics_processing is not Metabolomics or NOM, raise an error
+    if omics_processing.omics_type.has_raw_value not in ("Metabolomics", "Organic Matter Characterization"):
+        raise ValueError(f"Omics Processing omics_type is not Metabolomics or NOM: {omics_processing.omics_type.has_raw_value}")
+    if updated_omics_processing.omics_type.has_raw_value not in ("Metabolomics", "Organic Matter Characterization"):
+        raise ValueError(f"Updated Omics Processing omics_type is not Metabolomics or NOM: {updated_omics_processing.omics_type.has_raw_value}")
+
+
+    # OmicsProcessing has_output goes to the Activity's has_input
+    # We assume there is only one data object in has_output
+    omics_processing_output_id = omics_processing.has_output[0]
+    omics_processing_output_record = db_client["data_object_set"].find_one(
+        {"id": omics_processing_output_id}
+    )
+    omics_processing_output__id = omics_processing_output_record.pop("_id")
+    omics_processing_output_data_object = nmdc.DataObject(**omics_processing_output_record)
+    updated_omics_processing_output_data_object = update_omics_output_data_object(
+        omics_processing_output_data_object, updated_omics_processing, api_client, identifiers_map
+    )
+    # Update the parent OmicsProcessing record with the new has_output data object
+    updated_omics_processing.has_output = [updated_omics_processing_output_data_object.id]
+
+    if omics_processing_output_data_object.id != updated_omics_processing_output_data_object.id:
+        updated_record_identifiers.add(
+            ("data_object_set", omics_processing_output_data_object.id,
+             updated_omics_processing_output_data_object.id)
+        )
+    omics_processing_output_update = compare_models(
+        omics_processing_output_data_object,
+        updated_omics_processing_output_data_object
+    )
+    if omics_processing_output_update:
+        updates["data_object_set"][omics_processing_output__id] = (omics_processing_output_data_object,
+                                                                   omics_processing_output_update)
+
+    # ====== Metabolomics Analysis Activity Update ======
+    # Find all Metabolomics Analysis Activity records was_informed_by either OmicsProcessing
+    # and has_input either data object
+    omics_processing_ids = [omics_processing.id, updated_omics_processing.id]
+    data_object_ids = [omics_processing_output_data_object.id, updated_omics_processing_output_data_object.id]
+    activity_query = {
+        "$and": [
+            {"was_informed_by": {"$in": omics_processing_ids}},
+            {"has_input": {"$in": data_object_ids}}
+        ]
+    }
+    if updated_omics_processing.omics_type.has_raw_value == "Metabolomics":
+        set_name = "metabolomics_analysis_activity_set"
+    else:
+        set_name = "nom_analysis_activity_set"
+    activity_records = db_client[set_name].find(activity_query)
+
+    logging.info(f"Found {len(list(activity_records.clone()))} Records for {set_name}")
+
+    for activity_record in activity_records:
+        metabolomics_analysis_activity__id = activity_record.pop("_id")
+
+        if updated_omics_processing.omics_type.has_raw_value == "Metabolomics":
+            activity = nmdc.MetabolomicsAnalysisActivity(**activity_record)
+        else:
+            activity = nmdc.NomAnalysisActivity(**activity_record)
+
+        # has_output data objects
+        metabolomics_has_output_ids = activity.has_output
+        updated_activity_has_output_ids = []
+        for metabolomics_has_output_id in metabolomics_has_output_ids:
+            metabolomics_output_record = db_client["data_object_set"].find_one({"id": metabolomics_has_output_id})
+            metabolomics_output__id = metabolomics_output_record.pop("_id")
+            metabolomics_output_data_object = nmdc.DataObject(**metabolomics_output_record)
+            updated_metabolomics_output_data_object = update_data_object(
+                metabolomics_output_data_object, api_client, identifiers_map
+            )
+            updated_activity_has_output_ids.append(updated_metabolomics_output_data_object.id)
+            if metabolomics_output_data_object.id != updated_metabolomics_output_data_object.id:
+                updated_record_identifiers.add(
+                    ("data_object_set", metabolomics_output_data_object.id,
+                     updated_metabolomics_output_data_object.id)
+                )
+            metabolomics_output_data_object_update = compare_models(
+                metabolomics_output_data_object, updated_metabolomics_output_data_object
+            )
+            if metabolomics_output_data_object_update:
+                updates["data_object_set"][metabolomics_output__id] = (
+                    metabolomics_output_data_object, metabolomics_output_data_object_update)
+
+        # has_calibration_data data object for some activities
+        if updated_omics_processing.omics_type.has_raw_value == "Metabolomics":
+            calibration_data_object_id = activity.has_calibration
+            calibration_data_object_record = db_client["data_object_set"].find_one(
+                {"id": calibration_data_object_id}
+            )
+            calibration_data_object__id = calibration_data_object_record.pop("_id")
+            calibration_data_object = nmdc.DataObject(**calibration_data_object_record)
+            updated_calibration_data_object = update_data_object(
+                calibration_data_object, api_client, identifiers_map
+            )
+            if calibration_data_object.id != updated_calibration_data_object.id:
+                updated_record_identifiers.add(
+                    ("data_object_set", calibration_data_object.id, updated_calibration_data_object.id)
+                )
+            calibration_data_object_update = compare_models(
+                calibration_data_object, updated_calibration_data_object
+            )
+            if calibration_data_object_update:
+                updates["data_object_set"][calibration_data_object__id] = (
+                    calibration_data_object, calibration_data_object_update)
+
+            # Update the Metabolomics Analysis Activity record
+            updated_metabolomics_analysis_activity = update_metabolomics_analysis_activity(
+                metabolomics_analysis_activity=activity,
+                nmdc_omics_processing_id=updated_omics_processing.id,
+                nmdc_input_data_object_id=updated_omics_processing_output_data_object.id,
+                nmdc_output_data_object_ids=updated_activity_has_output_ids,
+                nmdc_calibration_data_object_id=updated_calibration_data_object.id,
+                api_client=api_client,
+                identifiers_map=identifiers_map
+            )
+            if activity.id != updated_metabolomics_analysis_activity.id:
+                updated_record_identifiers.add(
+                    ("metabolomics_analysis_activity_set", activity.id, updated_metabolomics_analysis_activity.id)
+                )
+            metabolomics_analysis_activity_update = compare_models(activity, updated_metabolomics_analysis_activity)
+            if metabolomics_analysis_activity_update:
+                updates["metabolomics_analysis_activity_set"][metabolomics_analysis_activity__id] = (
+                    activity, metabolomics_analysis_activity_update
+                )
+
+        else:
+            # Update the NOM Analysis Activity record
+            updated_nom_analysis_activity = update_nom_analysis_activity(
+                nom_analysis_activity=activity,
+                nmdc_omics_processing_id=updated_omics_processing.id,
+                nmdc_input_data_object_id=updated_omics_processing_output_data_object.id,
+                nmdc_output_data_object_ids=updated_activity_has_output_ids,
+                api_client=api_client,
+                identifiers_map=identifiers_map
+            )
+            if activity.id != updated_nom_analysis_activity.id:
+                updated_record_identifiers.add(
+                    ("nom_analysis_activity_set", activity.id, updated_nom_analysis_activity.id)
+                )
+            nom_analysis_activity_update = compare_models(activity, updated_nom_analysis_activity)
+            if nom_analysis_activity_update:
+                updates["nom_analysis_activity_set"][metabolomics_analysis_activity__id] = (
+                    activity, nom_analysis_activity_update
+                )
+
+    return updated_omics_processing, updated_record_identifiers, updates

--- a/nmdc_automation/re_iding/scripts/re_id_tool.py
+++ b/nmdc_automation/re_iding/scripts/re_id_tool.py
@@ -298,8 +298,6 @@ def update_study(ctx, legacy_study_id, nmdc_study_id,  mongo_uri, identifiers_fi
                 logging.exception(f"An error occurred while updating records: {e}")
                 sys.exit(1)
 
-
-
     logging.info("Writing updates and updated record identifiers to files")
     _write_updates(updates, nmdc_study_id)
     # Don't overwrite the identifiers file if it was provided

--- a/nmdc_automation/re_iding/scripts/re_id_tool.py
+++ b/nmdc_automation/re_iding/scripts/re_id_tool.py
@@ -24,12 +24,8 @@ from nmdc_automation.re_iding.base import (
     ReIdTool,
     _get_biosample_legacy_id,
     compare_models,
-    update_biosample,
-    update_data_object,
-    update_omics_processing,
-    update_omics_output_data_object,
-    update_metabolomics_analysis_activity,
-    update_nom_analysis_activity
+    get_updates_for_metabolomics_or_nom, update_biosample,
+    update_omics_processing
 )
 from nmdc_automation.re_iding.db_utils import get_omics_processing_id, ANALYSIS_ACTIVITIES
 
@@ -251,127 +247,13 @@ def update_study(ctx, legacy_study_id, nmdc_study_id,  mongo_uri, identifiers_fi
             updated_omics_processing = update_omics_processing(
                 omics_processing, nmdc_study_id, biosample.id, api_client, identifiers_map)
 
-            # ===== Metabolomics OmicsProcessing Update =====
-            if updated_omics_processing.omics_type.has_raw_value in ["Metabolomics", "Organic Matter Characterization"]:
-                # OmicsProcessing has_output goes to the Activity's has_input
-                # We assume there is only one data object in has_output
-                omics_processing_output_id = omics_processing.has_output[0]
-                omics_processing_output_record = db_client["data_object_set"].find_one(
-                    {"id": omics_processing_output_id})
-                omics_processing_output__id = omics_processing_output_record.pop("_id")
-                omics_processing_output_data_object = nmdc.DataObject(**omics_processing_output_record)
-                updated_omics_processing_output_data_object = update_omics_output_data_object(
-                    omics_processing_output_data_object, updated_omics_processing, api_client, identifiers_map
-                    )
-                # Update the parent OmicsProcessing record with the new has_output data object
-                updated_omics_processing.has_output = [updated_omics_processing_output_data_object.id]
-
-                if omics_processing_output_data_object.id != updated_omics_processing_output_data_object.id:
-                    updated_record_identifiers.add(("data_object_set", omics_processing_output_data_object.id,
-                                                    updated_omics_processing_output_data_object.id))
-                omics_processing_output_update = compare_models(omics_processing_output_data_object,
-                                           updated_omics_processing_output_data_object)
-                if omics_processing_output_update:
-                    updates["data_object_set"][omics_processing_output__id] = (omics_processing_output_data_object,
-                                                                               omics_processing_output_update)
-
-                #====== Metabolomics Analysis Activity Update ======
-                # Find all Metabolomics Analysis Activity records was_informed_by either OmicsProcessing
-                # and has_input either data object
-                omics_processing_ids = [omics_processing.id, updated_omics_processing.id]
-                data_object_ids = [omics_processing_output_data_object.id, updated_omics_processing_output_data_object.id]
-                activity_query = {
-                    "$and": [
-                        {"was_informed_by": {"$in": omics_processing_ids}},
-                        {"has_input": {"$in": data_object_ids}}
-                    ]
-                }
-                if updated_omics_processing.omics_type.has_raw_value == "Metabolomics":
-                    set_name = "metabolomics_analysis_activity_set"
-                else:
-                    set_name = "nom_analysis_activity_set"
-                activity_records = db_client[set_name].find(activity_query)
-
-                logging.info(f"Found {len(list(activity_records.clone()))} Records for {set_name}")
-
-                for activity_record in activity_records:
-                    metabolomics_analysis_activity__id = activity_record.pop("_id")
-
-                    if updated_omics_processing.omics_type.has_raw_value == "Metabolomics":
-                        activity = nmdc.MetabolomicsAnalysisActivity(**activity_record)
-                    else:
-                        activity = nmdc.NomAnalysisActivity(**activity_record)
-
-                    # has_output data objects
-                    metabolomics_has_output_ids = activity.has_output
-                    updated_activity_has_output_ids = []
-                    for metabolomics_has_output_id in metabolomics_has_output_ids:
-                        metabolomics_output_record = db_client["data_object_set"].find_one({"id": metabolomics_has_output_id})
-                        metabolomics_output__id = metabolomics_output_record.pop("_id")
-                        metabolomics_output_data_object = nmdc.DataObject(**metabolomics_output_record)
-                        updated_metabolomics_output_data_object = update_data_object(
-                            metabolomics_output_data_object, api_client, identifiers_map
-                        )
-                        updated_activity_has_output_ids.append(updated_metabolomics_output_data_object.id)
-                        if metabolomics_output_data_object.id != updated_metabolomics_output_data_object.id:
-                            updated_record_identifiers.add(("data_object_set", metabolomics_output_data_object.id,
-                                                            updated_metabolomics_output_data_object.id))
-                        metabolomics_output_data_object_update = compare_models(metabolomics_output_data_object, updated_metabolomics_output_data_object)
-                        if metabolomics_output_data_object_update:
-                            updates["data_object_set"][metabolomics_output__id] = (metabolomics_output_data_object, metabolomics_output_data_object_update)
-
-                    # has_calibration_data data object for some activities
-                    if updated_omics_processing.omics_type.has_raw_value == "Metabolomics":
-                        calibration_data_object_id = activity.has_calibration
-                        calibration_data_object_record = db_client["data_object_set"].find_one({"id": calibration_data_object_id})
-                        calibration_data_object__id = calibration_data_object_record.pop("_id")
-                        calibration_data_object = nmdc.DataObject(**calibration_data_object_record)
-                        updated_calibration_data_object = update_data_object(
-                            calibration_data_object, api_client, identifiers_map
-                        )
-                        if calibration_data_object.id != updated_calibration_data_object.id:
-                            updated_record_identifiers.add(("data_object_set", calibration_data_object.id, updated_calibration_data_object.id))
-                        calibration_data_object_update = compare_models(calibration_data_object, updated_calibration_data_object)
-                        if calibration_data_object_update:
-                            updates["data_object_set"][calibration_data_object__id] = (calibration_data_object, calibration_data_object_update)
-
-                        # Update the Metabolomics Analysis Activity record
-                        updated_metabolomics_analysis_activity = update_metabolomics_analysis_activity(
-                            metabolomics_analysis_activity=activity,
-                            nmdc_omics_processing_id=updated_omics_processing.id,
-                            nmdc_input_data_object_id=updated_omics_processing_output_data_object.id,
-                            nmdc_output_data_object_ids=updated_activity_has_output_ids,
-                            nmdc_calibration_data_object_id=updated_calibration_data_object.id,
-                            api_client=api_client,
-                            identifiers_map=identifiers_map
-                        )
-                        if activity.id != updated_metabolomics_analysis_activity.id:
-                            updated_record_identifiers.add(
-                                ("metabolomics_analysis_activity_set", activity.id, updated_metabolomics_analysis_activity.id))
-                        metabolomics_analysis_activity_update = compare_models(activity, updated_metabolomics_analysis_activity)
-                        if metabolomics_analysis_activity_update:
-                            updates["metabolomics_analysis_activity_set"][metabolomics_analysis_activity__id] = (
-                                activity, metabolomics_analysis_activity_update
-                            )
-
-                    else:
-                        # Update the NOM Analysis Activity record
-                        updated_nom_analysis_activity = update_nom_analysis_activity(
-                            nom_analysis_activity=activity,
-                            nmdc_omics_processing_id=updated_omics_processing.id,
-                            nmdc_input_data_object_id=updated_omics_processing_output_data_object.id,
-                            nmdc_output_data_object_ids=updated_activity_has_output_ids,
-                            api_client=api_client,
-                            identifiers_map=identifiers_map
-                        )
-                        if activity.id != updated_nom_analysis_activity.id:
-                            updated_record_identifiers.add(
-                                ("nom_analysis_activity_set", activity.id, updated_nom_analysis_activity.id))
-                        nom_analysis_activity_update = compare_models(activity, updated_nom_analysis_activity)
-                        if nom_analysis_activity_update:
-                            updates["nom_analysis_activity_set"][metabolomics_analysis_activity__id] = (
-                                activity, nom_analysis_activity_update
-                            )
+            # ===== Additional updates for Metabolomics and Organic Matter Characterization =====
+            ANALYSIS_ACTIVITIES = ("Metabolomics", "Organic Matter Characterization")
+            if updated_omics_processing.omics_type.has_raw_value in ANALYSIS_ACTIVITIES:
+                updated_omics_processing, updated_record_identifiers, updates = get_updates_for_metabolomics_or_nom(
+                    omics_processing, updated_omics_processing, api_client, db_client, identifiers_map,
+                    updated_record_identifiers, updates
+                )
 
             if omics_processing.id != updated_omics_processing.id:
                 updated_record_identifiers.add(("omics_processing_set", omics_processing.id, updated_omics_processing.id))

--- a/nmdc_automation/re_iding/tests/conftest.py
+++ b/nmdc_automation/re_iding/tests/conftest.py
@@ -41,3 +41,9 @@ def metabolomics_input_data_object_record():
     """Return a dict of a test nmdc_metabolomics_input_data_object instance"""
     with open(TEST_DATA_DIR / "metabolomics_input_data_object_record.json", "r") as f:
         return json.load(f)
+
+@pytest.fixture
+def metabolomics_output_data_object_record():
+    """Return a dict of a test nmdc_metabolomics_output_data_object instance"""
+    with open(TEST_DATA_DIR / "metabolomics_output_data_object_record.json", "r") as f:
+        return json.load(f)

--- a/nmdc_automation/re_iding/tests/test_data/metabolomics_output_data_object_record.json
+++ b/nmdc_automation/re_iding/tests/test_data/metabolomics_output_data_object_record.json
@@ -1,0 +1,11 @@
+{
+    "id" : "nmdc:c0f8177e881e53d2fd9305597be7a400",
+    "name" : "Blanch_Nat_Met_H_34_AB_M_01.csv",
+    "description" : "MetaMS GC-MS metabolomics output detail CSV file",
+    "file_size_bytes" : 698358,
+    "md5_checksum" : "c0f8177e881e53d2fd9305597be7a400",
+    "url" : "https://nmdcdemo.emsl.pnnl.gov/metabolomics/results/Blanch_Nat_Met_H_34_AB_M_01.csv",
+    "was_generated_by" : "nmdc:8969f454c3944f1eac9da499fb950a18",
+    "type" : "nmdc:DataObject",
+    "data_object_type" : "GC-MS Metabolomics Results"
+}

--- a/nmdc_automation/re_iding/tests/test_re_iding_base.py
+++ b/nmdc_automation/re_iding/tests/test_re_iding_base.py
@@ -14,7 +14,7 @@ from nmdc_automation.re_iding.base import (
     update_biosample,
     compare_models,
     get_new_nmdc_id,
-    update_metabolomics_analysis_activity,
+    _update_metabolomics_analysis_activity,
     update_omics_output_data_object,
     update_metabolomics_or_nom_data_object
 )
@@ -152,26 +152,22 @@ def test_update_metabolomics_analysis_activity(metabolomics_analysis_activity_re
     """
     Test that we can update a MetabolomicsAnalysisActivity.
     """
-    exp_id = "nmdc:1234-abcd12345"
+    exp_activity_id = "nmdc:wfmb-1234-abcd12345"
     exp_omics_processing_id = "nmdc:omprc-1234-abcd12345"
     exp_data_object_id = "nmdc:dobj-1234-abcd12345"
     exp_output_data_object_ids = ["nmdc:dobj-1234-abcd12345"]
     exp_calibration_data_object_ids = "nmdc:dobj-calibration-1234-abcd12345"
     mock_api = mocker.Mock(spec=NmdcRuntimeApi)
-    mock_api.minter.return_value = exp_id
+    mock_api.minter.return_value = exp_activity_id
 
     orig_id = metabolomics_analysis_activity_record["id"]
     metabolomics = MetabolomicsAnalysisActivity(**metabolomics_analysis_activity_record)
-    updated_metabolomics = update_metabolomics_analysis_activity(
-        metabolomics,
-        exp_omics_processing_id,
-        exp_data_object_id,
-        exp_output_data_object_ids,
-        exp_calibration_data_object_ids,
-        mock_api
-    )
+    updated_metabolomics = _update_metabolomics_analysis_activity(
+        exp_activity_id, metabolomics, exp_omics_processing_id, exp_data_object_id, exp_output_data_object_ids,
+        exp_calibration_data_object_ids
+        )
     assert isinstance(updated_metabolomics, MetabolomicsAnalysisActivity)
-    assert updated_metabolomics.id == exp_id
+    assert updated_metabolomics.id == exp_activity_id
 
     assert updated_metabolomics.was_informed_by == exp_omics_processing_id
     assert updated_metabolomics.has_input == [exp_data_object_id]

--- a/nmdc_automation/re_iding/tests/test_re_iding_base.py
+++ b/nmdc_automation/re_iding/tests/test_re_iding_base.py
@@ -21,7 +21,7 @@ from nmdc_automation.re_iding.base import (
 
 TEST_DATAFILE_DIR = "./test_data/results"
 
-def test_update_omics_processing_has_output(db_record, mocker):
+def test_reidtool_update_omics_processing_has_output(db_record, mocker):
     """
     Test that we can get a new Database with updated omics processing has_output
     and re-IDed data objects.
@@ -38,7 +38,7 @@ def test_update_omics_processing_has_output(db_record, mocker):
     assert new_db.omics_processing_set[0].has_output[0] == exp_do_id
 
 
-def test_make_new_data_object(data_object_record, mocker):
+def test_reidtool_make_new_data_object(data_object_record, mocker):
     """
     Test that we can make a new DataObject with a new ID and correct
     URL and Path attributes.
@@ -199,3 +199,4 @@ def test_update_omics_output_data_object(data_object_record, mocker):
     assert isinstance(updated_data_object, NmdcDataObject)
     assert updated_data_object.id == exp_id
     assert updated_data_object.alternative_identifiers == [orig_id]
+

--- a/nmdc_automation/re_iding/tests/test_re_iding_base.py
+++ b/nmdc_automation/re_iding/tests/test_re_iding_base.py
@@ -16,6 +16,7 @@ from nmdc_automation.re_iding.base import (
     get_new_nmdc_id,
     update_metabolomics_analysis_activity,
     update_omics_output_data_object,
+    update_metabolomics_or_nom_data_object
 )
 
 
@@ -199,4 +200,23 @@ def test_update_omics_output_data_object(data_object_record, mocker):
     assert isinstance(updated_data_object, NmdcDataObject)
     assert updated_data_object.id == exp_id
     assert updated_data_object.alternative_identifiers == [orig_id]
+
+def test_update_metabolomics_or_nom_data_object(metabolomics_output_data_object_record, mocker):
+    """
+    Test that we can update a Metabolomics or NOM DataObject with both a new ID and
+    updated was_generated_by.
+    """
+    exp_do_id = "nmdc:dobj-1234-abcd12345"
+    exp_was_generated_by = "nmdc:activity-1234-abcd12345"
+    data_object = NmdcDataObject(**metabolomics_output_data_object_record)
+
+    mock_api = mocker.Mock(spec=NmdcRuntimeApi)
+    mock_api.minter.return_value = exp_do_id
+
+    updated_data_object = update_metabolomics_or_nom_data_object(
+        data_object, mock_api, identifiers_map=None, was_generated_by=exp_was_generated_by)
+    assert isinstance(updated_data_object, NmdcDataObject)
+    assert updated_data_object.id == exp_do_id
+    assert updated_data_object.was_generated_by == exp_was_generated_by
+
 


### PR DESCRIPTION
Changes is this PR
- modify the `update_data_object` function to take a was_generated_by option
- refactor Metabolomics and NOM special processing to its own function
- refactor the update functions for Metab and NOM activities to require a new ID
- Generate the new ID early and use it for was_generated_by in the updated data objects

Example from local testing:
```
{
    "_id" : ObjectId("649b00401ae706d7b5b16e7b"),
    "id" : "nmdc:dobj-11-mvcbef22",
    "name" : "Froze_Core_2015_S3_50_60_4_Metab.csv",
    "description" : "MetaMS GC-MS metabolomics output detail CSV file",
    "file_size_bytes" : NumberInt(331968),
    "md5_checksum" : "f582dfddb0869611ec48feef6c6e702f",
    "url" : "https://nmdcdemo.emsl.pnnl.gov/metabolomics/results/Froze_Core_2015_S3_50_60_4_Metab.csv",
    "was_generated_by" : "nmdc:wfmb-11-7sdgmb18",
    "type" : "nmdc:DataObject",
    "data_object_type" : "GC-MS Metabolomics Results"
}
``` 