### PR TITLE
Add response status code and text to minter error message

### DIFF
--- a/nmdc_automation/api/nmdcapi.py
+++ b/nmdc_automation/api/nmdcapi.py
@@ -96,7 +96,7 @@ class NmdcRuntimeApi:
         data = {"schema_class": {"id": id_type}, "how_many": 1}
         resp = requests.post(url, data=json.dumps(data), headers=self.header)
         if not resp.ok:
-            raise ValueError(f"Failed to mint ID of type {id_type}")
+            raise ValueError(f"Minter failed for id type {id_type} error code {resp.status_code} / {resp.text}")
         id = resp.json()[0]
         if informed_by:
             url = f"{self._base_url}pids/bind"

--- a/nmdc_automation/api/nmdcapi.py
+++ b/nmdc_automation/api/nmdcapi.py
@@ -96,7 +96,7 @@ class NmdcRuntimeApi:
         data = {"schema_class": {"id": id_type}, "how_many": 1}
         resp = requests.post(url, data=json.dumps(data), headers=self.header)
         if not resp.ok:
-            raise ValueError(f"Minter failed for id type {id_type} error code {resp.status_code} / {resp.text}")
+            raise ValueError(f"Failed to mint ID of type {id_type} HTTP status: {resp.status_code} / ({resp.reason})")
         id = resp.json()[0]
         if informed_by:
             url = f"{self._base_url}pids/bind"


### PR DESCRIPTION
This PR updates the error message for the `minter` api client method. The error message now includes HTTP response code and text