### PR TITLE
Remove workflow_iteration add functionality to get_new_nmdc_id

### DIFF
--- a/nmdc_automation/re_iding/base.py
+++ b/nmdc_automation/re_iding/base.py
@@ -88,10 +88,9 @@ logger = logging.getLogger(__name__)
 
 class ReIdTool:
     def __init__(self, api_client: NmdcRuntimeApi, data_dir: str,
-                 template_file: str = None, iteration: str = "1", identifiers_map: dict = None):
+                 template_file: str = None, identifiers_map: dict = None):
         self.api_client = api_client
         self.data_dir = data_dir
-        self.workflow_iteration = iteration
         if template_file is None:
             template_file = NAPA_TEMPLATE
         with open(template_file, "r") as f:
@@ -212,8 +211,7 @@ class ReIdTool:
             has_input = new_omics_processing.has_output
             
             activity_obj = nmdc.ReadQcAnalysisActivity(**reads_qc_rec)
-            new_activity_id = get_new_nmdc_id(
-                activity_obj, self.api_client, self.identifiers_map) + "." + self.workflow_iteration
+            new_activity_id = get_new_nmdc_id(activity_obj, self.api_client, self.identifiers_map)
 
             self.updated_record_identifiers.add((READS_QC_SET, reads_qc_rec["id"], new_activity_id))
             logging.info(f"New activity id created for {omics_processing_id} activity type {activity_type}: {new_activity_id}")
@@ -285,8 +283,7 @@ class ReIdTool:
             updated_has_output = []
             activity_obj = nmdc.MetagenomeAssembly(**assembly_rec)
             activity_obj.type = activity_type
-            new_activity_id = get_new_nmdc_id(
-                activity_obj, self.api_client, self.identifiers_map) + "." + self.workflow_iteration
+            new_activity_id = get_new_nmdc_id(activity_obj, self.api_client, self.identifiers_map)
 
             self.updated_record_identifiers.add((METAGENOME_ASSEMBLY_TYPE, assembly_rec["id"], new_activity_id))
             logging.info(f"New activity id created for {omics_processing_id} activity type {activity_type}: {new_activity_id}")
@@ -376,8 +373,7 @@ class ReIdTool:
             has_input = [self._get_input_do_id(new_db, "Filtered Sequencing Reads")]
             activity_obj = nmdc.ReadBasedTaxonomyAnalysisActivity(**read_based_rec)
             activity_obj.type = activity_type
-            new_activity_id = get_new_nmdc_id(
-                activity_obj, self.api_client, self.identifiers_map) + "." + self.workflow_iteration
+            new_activity_id = get_new_nmdc_id(activity_obj, self.api_client, self.identifiers_map)
 
             self.updated_record_identifiers.add((READ_BASED_TAXONOMY_ANALYSIS_ACTIVITY_SET, read_based_rec["id"],
                                                new_activity_id))
@@ -466,8 +462,7 @@ class ReIdTool:
 
             activity_obj = nmdc.MetatranscriptomeActivity(**metatranscriptome_rec)
             activity_obj.type = activity_type
-            new_activity_id = get_new_nmdc_id(
-                activity_obj, self.api_client, self.identifiers_map) + "." + self.workflow_iteration
+            new_activity_id = get_new_nmdc_id(activity_obj, self.api_client, self.identifiers_map)
 
             self.updated_record_identifiers.add((METATRANSCRIPTOME_ACTIVITY_SET, metatranscriptome_rec["id"],
                                                new_activity_id))
@@ -666,6 +661,9 @@ def get_new_nmdc_id(nmdc_object, api_client, identifiers_map: dict = None) -> st
         logging.info(f"Found new ID in identifiers_map: {new_id}")
     else:
         new_id = api_client.minter(object_type_code)
+        # For new workflow IDs, we assume that the .version is 1
+        if new_id.startswith("nmdc:wf") and not new_id.endswith(".1"):
+            new_id = new_id + ".1"
         logging.info(f"Minted new ID: {new_id}")
     return new_id
 

--- a/nmdc_automation/re_iding/tests/test_re_iding_base.py
+++ b/nmdc_automation/re_iding/tests/test_re_iding_base.py
@@ -131,6 +131,21 @@ def test_get_new_id_data_object(mocker):
     new_id = get_new_nmdc_id(nmdc_object, mock_api)
     assert new_id == exp_id
 
+def test_get_new_id_metabolomics_analysis_activity(mocker):
+    """
+    Test that we can get a new NMDC ID with a .1 suffix.
+    """
+    exp_api_return = "nmdc:wfmb-1234-abcd12345"
+    exp_id = "nmdc:wfmb-1234-abcd12345.1"
+    mock_api = mocker.Mock(spec=NmdcRuntimeApi)
+    mock_api.minter.return_value = exp_api_return
+
+    nmdc_object = mocker.Mock(spec=MetabolomicsAnalysisActivity)
+    nmdc_object.type.return_value = "nmdc:MetabolomicsAnalysisActivity"
+
+    new_id = get_new_nmdc_id(nmdc_object, mock_api)
+    assert new_id == exp_id
+
 def test_get_new_nmdc_id_biosample_with_identifiers_map(mocker):
     """
     Test that we can get a new NMDC ID with an identifiers_map.
@@ -155,9 +170,10 @@ def test_get_new_nmdc_id_nom_activity_ndmc_typo_in_type(nom_activity_record_ndmc
     """
     Test that we can get a new NMDC ID for a NOM Activity with a typo in the type.
     """
-    exp_id = "nmdc:1234-abcd12345"
+    exp_api_id = "nmdc:wfnom-1234-abcd12345"
+    exp_id = "nmdc:wfnom-1234-abcd12345.1"
     mock_api = mocker.Mock(spec=NmdcRuntimeApi)
-    mock_api.minter.return_value = exp_id
+    mock_api.minter.return_value = exp_api_id
 
     nmdc_object = NomAnalysisActivity(**nom_activity_record_ndmc)
 
@@ -178,19 +194,16 @@ def test_get_new_nmdc_id_nom_activity_ndmc_typo_in_type_with_identifiers_map(nom
     new_id = get_new_nmdc_id(nmdc_object, mock_api, identifiers_map)
     assert new_id == exp_id
 
-def test_update_metabolomics_analysis_activity(metabolomics_analysis_activity_record, mocker):
+def test_update_metabolomics_analysis_activity(metabolomics_analysis_activity_record):
     """
     Test that we can update a MetabolomicsAnalysisActivity.
     """
+    exp_api_return = "nmdc:wfmb-1234-abcd12345"
     exp_activity_id = "nmdc:wfmb-1234-abcd12345"
     exp_omics_processing_id = "nmdc:omprc-1234-abcd12345"
     exp_data_object_id = "nmdc:dobj-1234-abcd12345"
     exp_output_data_object_ids = ["nmdc:dobj-1234-abcd12345"]
     exp_calibration_data_object_ids = "nmdc:dobj-calibration-1234-abcd12345"
-    mock_api = mocker.Mock(spec=NmdcRuntimeApi)
-    mock_api.minter.return_value = exp_activity_id
-
-    orig_id = metabolomics_analysis_activity_record["id"]
     metabolomics = MetabolomicsAnalysisActivity(**metabolomics_analysis_activity_record)
     updated_metabolomics = _update_metabolomics_analysis_activity(
         exp_activity_id, metabolomics, exp_omics_processing_id, exp_data_object_id, exp_output_data_object_ids,


### PR DESCRIPTION
Provides an updates in the re-iding base class
- ReIDTool class: remove the workflow_iteration logic which was mindlessly adding ".1" to identifiers
- Update get_new_nmdc_id method to append a ".1" if needed to new workflow activities

Note:  This is making an assumption for re-ID pruposes that if we are minting NEW workflow activity identifiers that they will have a .version of .1