### PR TITLE
Update process_records command to not overwrite existing files

### DIFF
--- a/nmdc_automation/re_iding/file_utils.py
+++ b/nmdc_automation/re_iding/file_utils.py
@@ -254,27 +254,36 @@ def get_old_file_path(data_object_record: dict, old_base_dir: Union[str, os.Path
 
 
 def assembly_file_operations(data_object_record, data_object_type,
-                             destination, act_id, old_base_dir):
+                             new_file_path, act_id, old_base_dir):
+    """
+    Perform file operations for different assembly data object types.
+    """
+    if new_file_path.exists():
+        logging.info(f"File already exists at {new_file_path}. Skipping processing.")
+        return None, None
+
     logging.info(f"Processing {data_object_type} for {act_id}")
-    logging.info(f"Destination: {destination}")
+    logging.info(f"Destination: {new_file_path}")
     logging.info(f"Old base dir: {old_base_dir}")
     # get old file path upfront
     old_file_path = get_old_file_path(data_object_record, old_base_dir)
     logging.info(f"Old file path: {old_file_path}")
 
     if data_object_type == "Assembly Coverage Stats":
-        md5, size = assembly_coverage_stats(old_file_path, destination, act_id)
+        md5, size = assembly_coverage_stats(old_file_path, new_file_path, act_id)
     elif data_object_type == "Assembly Contigs":
-        md5, size = assembly_contigs(old_file_path, destination, act_id)
+        md5, size = assembly_contigs(old_file_path, new_file_path, act_id)
     elif data_object_type == "Assembly Scaffolds":
-        md5, size = assembly_scaffolds(old_file_path, destination, act_id)
+        md5, size = assembly_scaffolds(old_file_path, new_file_path, act_id)
     elif data_object_type == "Assembly AGP":
-        md5, size = assembly_agp(old_file_path, destination, act_id)
+        md5, size = assembly_agp(old_file_path, new_file_path, act_id)
     elif data_object_type == "Assembly Coverage BAM":
         md5, size = assembly_coverage_bam(
-            old_file_path, destination, act_id
+            old_file_path, new_file_path, act_id
         )
-
+    else:
+        logging.error(f"Unsupported data object type: {data_object_type}")
+        md5, size = None, None
     return md5, size
 
 

--- a/nmdc_automation/re_iding/file_utils.py
+++ b/nmdc_automation/re_iding/file_utils.py
@@ -298,8 +298,19 @@ def compute_new_data_file_path(
 
 def link_data_file_paths(old_url: str, old_base_dir: Union[str, os.PathLike], new_path: Union[str, os.PathLike])-> \
         None:
-    suffix = old_url.split("https://data.microbiomedata.org/data/")[1]
+    base_url = "https://data.microbiomedata.org/data/"
+    if not old_url.startswith(base_url):
+        logging.error(f"The URL {old_url} does not start with the expected base URL {base_url}.")
+        return
+    # Extract the suffix and construct the old file path
+    suffix = old_url[len(base_url):]
     old_file_path = Path(old_base_dir, suffix)
+    new_file_path = Path(new_path)
+    # Check if the destination link already exists
+    if new_file_path.exists():
+        logging.info(f"File already exists at {new_file_path}. Skipping linking.")
+        return
+
     try:
         os.link(old_file_path, new_path)
         logging.info(f"Successfully created link between {old_file_path} and {new_path}")

--- a/nmdc_automation/re_iding/file_utils.py
+++ b/nmdc_automation/re_iding/file_utils.py
@@ -322,8 +322,8 @@ def link_data_file_paths(old_url: str, old_base_dir: Union[str, os.PathLike], ne
 
     try:
         os.link(old_file_path, new_path)
-        logging.info(f"Successfully created link between {old_file_path} and {new_path}")
+        logging.info(f"Successfully created link between {old_file_path} and {new_file_path}")
     except OSError as e:
-        logging.error(f"An error occurred while linking the file: {e}")
+        logging.error(f"An error occurred while linking the file from {old_file_path} to {new_file_path}: {e}")
     except Exception as e:
-        logging.error(f"Unexpected error: {e}")
+        logging.error(f"Unexpected error while linking the file from {old_file_path} to {new_file_path}: {e}")

--- a/nmdc_automation/re_iding/scripts/re_id_tool.py
+++ b/nmdc_automation/re_iding/scripts/re_id_tool.py
@@ -653,7 +653,7 @@ def process_records(ctx, study_id, data_dir, update_links=False, identifiers_fil
         identifiers_map = None
 
     # Initialize re-ID tool
-    reid_tool = ReIdTool(api_client, data_dir, identifiers_map = identifiers_map)
+    reid_tool = ReIdTool(api_client, data_dir, identifiers_map=identifiers_map)
 
     # Read extracted DB records
     logging.info(f"Using db_infile: {db_infile}")

--- a/nmdc_automation/re_iding/tests/test_file_utils.py
+++ b/nmdc_automation/re_iding/tests/test_file_utils.py
@@ -3,11 +3,14 @@ import pytest
 import shutil
 import tempfile
 import os
+from unittest import mock
+from pathlib import Path
 
 from nmdc_automation.re_iding.file_utils import (
     rewrite_bam,
     replace_and_write_bam,
-    md5_sum
+    md5_sum,
+    link_data_file_paths
 )
 
 @pytest.fixture
@@ -82,3 +85,77 @@ def test_replace_and_write_bam(sample_bam, tmpdir):
 
     # Check if the output BAM file is not empty
     assert os.path.getsize(output_bam) > 0
+
+
+def test_valid_link_creation(tmp_path):
+    old_base_dir = tmp_path / "old_base"
+    new_path = tmp_path / "new_link"
+    old_base_dir.mkdir(parents=True)
+    (old_base_dir / "path/to").mkdir(parents=True)
+    old_file = old_base_dir / "path/to/file.txt"
+    old_file.write_text("test content")
+
+    old_url = "https://data.microbiomedata.org/data/path/to/file.txt"
+
+    with mock.patch('os.link') as mock_link:
+        link_data_file_paths(old_url, old_base_dir, new_path)
+        mock_link.assert_called_once_with(old_file, new_path)
+
+def test_existing_link(tmp_path):
+    old_base_dir = tmp_path / "old_base"
+    new_path = tmp_path / "new_link"
+    old_base_dir.mkdir(parents=True)
+    (old_base_dir / "path/to").mkdir(parents=True)
+    old_file = old_base_dir / "path/to/file.txt"
+    old_file.write_text("test content")
+    new_path.write_text("test content")
+
+    old_url = "https://data.microbiomedata.org/data/path/to/file.txt"
+
+    with mock.patch('os.link') as mock_link:
+        with mock.patch('logging.info') as mock_log_info:
+            link_data_file_paths(old_url, old_base_dir, new_path)
+            mock_link.assert_not_called()
+            mock_log_info.assert_any_call(f"File already exists at {new_path}. Skipping linking.")
+
+def test_invalid_url():
+    old_base_dir = Path("/some/base/dir")
+    new_path = Path("/some/new/path")
+    old_url = "https://invalid.url/path/to/file.txt"
+
+    with mock.patch('logging.error') as mock_log_error:
+        link_data_file_paths(old_url, old_base_dir, new_path)
+        mock_log_error.assert_any_call(f"The URL {old_url} does not start with the expected base URL https://data.microbiomedata.org/data/.")
+
+def test_link_creation_error(tmp_path):
+    old_base_dir = tmp_path / "old_base"
+    new_path = tmp_path / "new_link"
+    old_base_dir.mkdir(parents=True)
+    (old_base_dir / "path/to").mkdir(parents=True)
+    old_file = old_base_dir / "path/to/file.txt"
+    old_file.write_text("test content")
+
+    old_url = "https://data.microbiomedata.org/data/path/to/file.txt"
+
+    with mock.patch('os.link', side_effect=OSError("link error")) as mock_link:
+        with mock.patch('logging.error') as mock_log_error:
+            link_data_file_paths(old_url, old_base_dir, new_path)
+            mock_link.assert_called_once_with(old_file, new_path)
+            mock_log_error.assert_any_call(f"An error occurred while linking the file from {old_file} to {new_path}: link error")
+
+def test_unexpected_error(tmp_path):
+    old_base_dir = tmp_path / "old_base"
+    new_path = tmp_path / "new_link"
+    old_base_dir.mkdir(parents=True)
+    (old_base_dir / "path/to").mkdir(parents=True)
+    old_file = old_base_dir / "path/to/file.txt"
+    old_file.write_text("test content")
+
+    old_url = "https://data.microbiomedata.org/data/path/to/file.txt"
+
+    with mock.patch('os.link', side_effect=Exception("unexpected error")) as mock_link:
+        with mock.patch('logging.error') as mock_log_error:
+            link_data_file_paths(old_url, old_base_dir, new_path)
+            mock_link.assert_called_once_with(old_file, new_path)
+            mock_log_error.assert_any_call(f"Unexpected error while linking the file from {old_file} to {new_path}: unexpected error")
+


### PR DESCRIPTION
This PR provides changes to 2 methods used in symbolic link creation and file re-writing for the `process-records` command.
- assembly_file_operations:   Add a check if the new file already exists, log and skip
- link_data_file_paths:  Add a check if the symbolic link already exists, log and skip