### PR TITLE
Skip downstream jobs for disabled workflows

### DIFF
--- a/configs/workflows.yaml
+++ b/configs/workflows.yaml
@@ -1,12 +1,14 @@
 Workflows:
   - Name: Sequencing Noninterleaved
     Collection: omics_processing_set
+    Enabled: True
     Filter Output Objects:
     - Metagenome Raw Read 1
     - Metagenome Raw Read 2
 
   - Name: Sequencing Interleaved
     Collection: omics_processing_set
+    Enabled: True
     Filter Output Objects:
     - Metagenome Raw Reads
 

--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -278,7 +278,11 @@ class Scheduler:
             if act.was_informed_by in skiplist:
                 logging.debug(f"Skipping: {act.was_informed_by}")
                 continue
+            if not act.workflow.enabled:
+                logging.debug(f"Skipping: {act.id}, workflow disabled.")
+                continue
             if allowlist and act.was_informed_by not in allowlist:
+                logging.debug(f"Skipping: {act.was_informed_by}, not in allow list.")
                 continue
             jobs = self.find_new_jobs(act)
             for job in jobs:

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -100,7 +100,6 @@ def test_submit(db, mock_api):
     assert len(resp) == 1
 
     # The job should now be in a submitted state
-    # make this pass
     resp = jm.cycle()
     assert len(resp) == 0
 

--- a/tests/workflows_test.yaml
+++ b/tests/workflows_test.yaml
@@ -1,12 +1,14 @@
 Workflows:
   - Name: Sequencing Noninterleaved
     Collection: omics_processing_set
+    Enabled: True
     Filter Output Objects:
     - Metagenome Raw Read 1
     - Metagenome Raw Read 2
 
   - Name: Sequencing Interleaved
     Collection: omics_processing_set
+    Enabled: True
     Filter Output Objects:
     - Metagenome Raw Reads
 

--- a/tests/workflows_test2.yaml
+++ b/tests/workflows_test2.yaml
@@ -1,12 +1,14 @@
 Workflows:
   - Name: Sequencing Noninterleaved
     Collection: omics_processing_set
+    Enabled: True
     Filter Output Objects:
     - Metagenome Raw Read 1
     - Metagenome Raw Read 2
 
   - Name: Sequencing Interleaved
     Collection: omics_processing_set
+    Enabled: True
     Filter Output Objects:
     - Metagenome Raw Reads
 


### PR DESCRIPTION
If an activity has a workflow that is disabled (e.g. old version), then we shouldn't trigger any downstream activities from that.