### PR TITLE
Fix dependency logic

### DIFF
--- a/nmdc_automation/workflow_automation/activities.py
+++ b/nmdc_automation/workflow_automation/activities.py
@@ -37,7 +37,7 @@ def _within_range(ver1: str, ver2: str) -> bool:
     """
 
     def get_version(version):
-        v_string = version.lstrip("b").lstrip("v")
+        v_string = version.lstrip("b").lstrip("v").rstrip("-beta")
         return Version.parse(v_string)
 
     v1 = get_version(ver1)
@@ -90,6 +90,7 @@ def _read_acitivites(db, workflows: List[Workflow],
         q["git_url"] = wf.git_repo
         for rec in db[wf.collection].find(q):
             if wf.version and not _within_range(rec["version"], wf.version):
+                logging.debug(f"Skipping {wf.name} {wf.version} {rec['version']}")
                 continue
             if wf.collection == "omics_processing_set" and \
                rec["id"].startswith("gold"):
@@ -134,7 +135,9 @@ def _resolve_relationships(activities, data_obj_act):
             # This is just a safeguard
             if act.was_informed_by != parent_act.was_informed_by:
                 logging.warning("Mismatched informed by for "
-                                f"{do_id} in {act.id}")
+                                f"{do_id} in {act.id} "
+                                f"{act.was_informed_by} != "
+                                f"{parent_act.was_informed_by}")
                 continue
             # We only want to use it as a parent if it is the right
             # parent workflow. Some inputs may come from ancestors

--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -48,7 +48,7 @@ def within_range(wf1: Workflow, wf2: Workflow, force=False) -> bool:
     v1 = get_version(wf1)
     v2 = get_version(wf2)
     if force:
-        return v1==v2
+        return v1 == v2
     if v1.major == v2.major and v1.minor == v2.minor:
         return True
     return False
@@ -267,7 +267,8 @@ class Scheduler:
 
         return new_jobs
 
-    def cycle(self, dryrun: bool = False, skiplist: set = set(), allowlist = None) -> list:
+    def cycle(self, dryrun: bool = False, skiplist: set = set(),
+              allowlist=None) -> list:
         """
         This function does a single cycle of looking for new jobs
         """

--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -272,7 +272,10 @@ class Scheduler:
         """
         This function does a single cycle of looking for new jobs
         """
-        acts = load_activities(self.db, self.workflows)
+        filt = None
+        if allowlist:
+            filt = {"was_informed_by": {"$in": list(allowlist)}}
+        acts = load_activities(self.db, self.workflows, filter=filt)
         self.get_existing_jobs.cache_clear()
         job_recs = []
         for act in acts:
@@ -282,14 +285,11 @@ class Scheduler:
             if not act.workflow.enabled:
                 logging.debug(f"Skipping: {act.id}, workflow disabled.")
                 continue
-            if allowlist and act.was_informed_by not in allowlist:
-                logging.debug(f"Skipping: {act.was_informed_by}, not in allow list.")
-                continue
             jobs = self.find_new_jobs(act)
             for job in jobs:
                 if dryrun:
                     msg = f"new job: informed_by: {job.informed_by} trigger: {job.trigger_id} "
-                    msg += f"wf: {job.workflow.name}"
+                    msg += f"wf: {job.workflow.name} ver: {job.workflow.version}"
                     logging.info(msg)
                     continue
                 try:
@@ -324,6 +324,8 @@ def main():  # pragma: no cover
                 allowlist.add(line.rstrip())
     while True:
         sched.cycle(dryrun=dryrun, skiplist=skiplist, allowlist=allowlist)
+        if dryrun:
+            break
         _sleep(_POLL_INTERVAL)
 
 

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -73,13 +73,16 @@ def init_test(db):
         load(db, fn, reset=True)
 
 
-def mock_progress(db, wf):
+def mock_progress(db, wf, version=None, flush=True):
     s = wf.collection
     data = read_json("%s.json" % (s))[0]
     if 'version' not in data:
         data['git_url'] = wf.git_repo
         data['version'] = wf.version
-    db[s].delete_many({})
+    if version:
+        data['version'] = version
+    if flush:
+        db[s].delete_many({})
     db[s].insert_one(data)
 
 
@@ -128,7 +131,10 @@ def test_progress(db, mock_api):
     assert len(resp) == 0
 
     wf = workflow_by_name['Metagenome Assembly']
-    mock_progress(db, wf)
+    # Lets override the version to simulate an older run
+    # for this workflow that is stil within range of the
+    # current workflow
+    mock_progress(db, wf, version="v1.0.2")
     resp = jm.cycle()
     assert "assembly_id" in resp[0]["config"]["inputs"]
     assert len(resp) == 1
@@ -191,3 +197,28 @@ def test_multiple_versions(db, mock_api):
     db.jobs.delete_many({})
     resp = jm.cycle()
     assert len(resp) == 4
+
+
+def test_out_of_range(db, mock_api):
+    init_test(db)
+    reset_db(db)
+    db.jobs.delete_many({})
+    load(db, "data_object_set.json")
+    load(db, "omics_processing_set.json")
+    jm = Scheduler(db, wfn="./tests/workflows_test.yaml",
+                   site_conf="./tests/site_configuration_test.toml")
+    workflow_by_name = dict()
+    for wf in jm.workflows:
+        workflow_by_name[wf.name] = wf
+
+    # Let's create two RQC records.  One will be in range
+    # and the other will not.  We should only get new jobs
+    # for the one in range.
+    wf = workflow_by_name['Reads QC']
+    mock_progress(db, wf)
+    mock_progress(db, wf, version="v0.0.1", flush=False)
+
+    resp = jm.cycle()
+    assert len(resp) == 2
+    resp = jm.cycle()
+    assert len(resp) == 0


### PR DESCRIPTION
This addresses issue #211.  This also has the benefit that we no longer need to have stub workflows defined for older versions.