### PR TITLE
update MetagenomeAnnotationActivity to version v1.1.0 in workflows.yaml

### DIFF
--- a/configs/workflows.yaml
+++ b/configs/workflows.yaml
@@ -168,7 +168,7 @@ Workflows:
     Type: nmdc:MetagenomeAnnotationActivity
     Enabled: True
     Git_repo: https://github.com/microbiomedata/mg_annotation
-    Version: v1.0.4
+    Version: v1.1.0
     WDL: annotation_full.wdl
     Collection: metagenome_annotation_activity_set
     Predecessors:
@@ -272,7 +272,7 @@ Workflows:
         data_object_type: Annotation Statistics
         description: Annotation Stats for {id}
         name: Annotation statistics report
-      - output: contig_mapping
+      - output: map_file
         data_object_type: Contig Mapping File
         description: Conging mappings file for {id}
         name: Contig mappings between contigs and scaffolds
@@ -280,6 +280,11 @@ Workflows:
         data_object_type: Annotation Info File
         description: Annotation info for {id}
         name: File containing annotation info
+      - output: renamed_fasta
+        data_object_type: Assembly Contigs
+        description: Assembly contigs (remapped) for {id}
+        name: File containing contigs with annotation headers
+
 
   - Name: MAGs
     Type: nmdc:MagsAnalysisActivity

--- a/configs/workflows.yaml
+++ b/configs/workflows.yaml
@@ -274,7 +274,7 @@ Workflows:
         name: Annotation statistics report
       - output: map_file
         data_object_type: Contig Mapping File
-        description: Conging mappings file for {id}
+        description: Contig mappings file for {id}
         name: Contig mappings between contigs and scaffolds
       - output: imgap_version
         data_object_type: Annotation Info File


### PR DESCRIPTION
This PR bumps the version of annotation to v1.1.0, fixes the wdl name of the contig mapping file and adds the annotation re-named contig fasta file.