### PR TITLE
Handle redundant types

### DIFF
--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -113,6 +113,9 @@ class Scheduler:
         do_by_type = dict()
         while next_act:
             for do_type, val in next_act.data_objects_by_type.items():
+                if do_type in do_by_type:
+                    logging.debug(f"Ignoring Duplicate type: {do_type} {val.id} {next_act.id}")
+                    continue
                 do_by_type[do_type] = val.__dict__
             # do_by_type.update(next_act.data_objects_by_type.__dict__)
             next_act = next_act.parent

--- a/tests/fixtures/data_object_set.json
+++ b/tests/fixtures/data_object_set.json
@@ -9,6 +9,15 @@
     "data_object_type": "Assembly Contigs"
   },
   {
+    "description": "Renamed Assembled contigs fasta for gold:Gp0213371",
+    "url": "https://data.microbiomedata.org/data/nmdc:mga0vx38/annotation/nmdc_mga0vx38_contigs.fna",
+    "md5_checksum": "37573bca240f88091720ae61ae5c9452",
+    "file_size_bytes": 1232092144,
+    "id": "nmdc:37573bca240f88091720ae61ae5c9454",
+    "name": "gold:Gp0213371_Assembled contigs fasta",
+    "data_object_type": "Assembly Contigs"
+  },
+  {
     "description": "Protein FAA for gold:Gp0213371",
     "url": "https://data.microbiomedata.org/data/nmdc:mga0vx38/annotation/nmdc_mga0vx38_proteins.faa",
     "md5_checksum": "7336ecf1f0b47e6161b52aec01d56ab8",

--- a/tests/fixtures/metagenome_annotation_activity_set.json
+++ b/tests/fixtures/metagenome_annotation_activity_set.json
@@ -27,7 +27,8 @@
       "nmdc:02f081900336db5b9553328c93c40d21",
       "nmdc:5b7a1c3890012eab0fb111979dd6ca3f",
       "nmdc:205d1c4d44756cdadc7f2263375cd5cc",
-      "nmdc:3c18be56eef0b4cdbc514764cb724f06"
+      "nmdc:3c18be56eef0b4cdbc514764cb724f06",
+      "nmdc:37573bca240f88091720ae61ae5c9454"
     ],
     "was_informed_by": "nmdc:omprc-11-nhy4pz43",
     "id": "nmdc:fdefb3fa15098906cf788f5cadf17bb3",

--- a/tests/workflows_test.yaml
+++ b/tests/workflows_test.yaml
@@ -311,6 +311,10 @@ Workflows:
         description: Annotation info for {id}
         name: File containing annotation info
         suffix: _imgap.info
+      - output: renamed_fasta
+        data_object_type: Assembly Contigs
+        description: Assembly contigs (remapped) for {id}
+        name: File containing contigs with annotation headers
 
   - Name: MAGs
     Type: nmdc:MagsAnalysisActivity


### PR DESCRIPTION
Some types are used for multiple activities.  This PR changes the behavior to use the closest hit working up the predecessor chain.  This also adds tests to confirm the correct behavior.