### PR TITLE
Metatranscriptome JGI ingest yaml config

### DIFF
--- a/configs/import-mt.yaml
+++ b/configs/import-mt.yaml
@@ -1,0 +1,476 @@
+Workflows:
+  - Name: Sequencing
+    Import: true
+    Type: nmdc:MetagenomeSequencingActivity
+    Git_repo: https://github.com/microbiomedata/RawSequencingData
+    Version: v1.0.0
+    Collection: metagenome_sequencing_activity_set
+    ActivityRange: MetagenomeSequencingActivity
+    Activity:
+      name: "Metagenome Sequencing Activity for {id}"
+      type: nmdc:MetagenomeSequencingActivity
+    Outputs:
+      - Metagenome Raw Reads
+
+  - Name: Metatranscriptome Reads QC
+    Import: true
+    Type: nmdc:ReadQcAnalysisActivity
+    Git_repo: https://github.com/microbiomedata/metaT_ReadsQC
+    Version: v0.0.3
+    Collection: read_qc_analysis_activity_set
+    ActivityRange: ReadQcAnalysisActivity
+    Inputs:
+      - Metagenome Raw Reads
+    Activity:
+      name: "Read QC Activity for {id}"
+      input_read_bases: "{outputs.stats.input_read_bases}"
+      input_read_count: "{outputs.stats.input_read_count}"
+      output_read_bases: "{outputs.stats.output_read_bases}"
+      output_read_count: "{outputs.stats.output_read_count}"
+      type: nmdc:ReadQcAnalysisActivity
+    Outputs:
+      - Filtered Sequencing Reads
+      - QC Statistics
+      - rRNA Filtered Sequencing Reads
+      - Read Filtering Info File
+
+  - Name: Metatranscriptome Assembly
+    Import: false
+    Type: nmdc:MetatranscriptomeAssembly
+    Git_repo: https://github.com/microbiomedata/metaT_Assembly
+    Version: v0.0.1
+    Collection: metatranscriptome_assembly_set
+    ActivityRange: MetatranscriptomeAssembly
+    Inputs:
+      - Filtered Sequencing Reads
+    Activity:
+      name: "Metagenome Assembly Activity for {id}"
+      type: nmdc:MetatranscriptomeAssembly
+      asm_score: "{outputs.stats.asm_score}"
+      contig_bp: "{outputs.stats.contig_bp}"
+      contigs: "{outputs.stats.contigs}"
+      ctg_l50: "{outputs.stats.ctg_l50}"
+      ctg_l90: "{outputs.stats.ctg_l90}"
+      ctg_logsum: "{outputs.stats.ctg_logsum}"
+      ctg_max: "{outputs.stats.ctg_max}"
+      ctg_n50: "{outputs.stats.ctg_n50}"
+      ctg_n90: "{outputs.stats.ctg_n90}"
+      ctg_powsum: "{outputs.stats.ctg_powsum}"
+      gap_pct: "{outputs.stats.gap_pct}"
+      gc_avg: "{outputs.stats.gc_avg}"
+      gc_std: "{outputs.stats.gc_std}"
+      scaf_bp: "{outputs.stats.scaf_bp}"
+      scaf_l50: "{outputs.stats.scaf_l50}"
+      scaf_l90: "{outputs.stats.scaf_l90}"
+      scaf_l_gt50k: "{outputs.stats.scaf_l_gt50k}"
+      scaf_logsum: "{outputs.stats.scaf_logsum}"
+      scaf_max: "{outputs.stats.scaf_max}"
+      scaf_n50: "{outputs.stats.scaf_n50}"
+      scaf_n90: "{outputs.stats.scaf_n90}"
+      scaf_n_gt50k: "{outputs.stats.scaf_n_gt50k}"
+      scaf_pct_gt50k: "{outputs.stats.scaf_pct_gt50k}"
+      scaf_powsum: "{outputs.stats.scaf_powsum}"
+      scaffolds: "{outputs.stats.scaffolds}"
+    Outputs:
+      - Assembly Contigs
+      - Assembly Coverage Stats
+      - Assembly Coverage BAM
+      - Assembly Info File
+      - BAI File
+
+  - Name: Metatranscriptome Annotation
+    Import: false
+    Type: nmdc:MetatranscriptomeAnnotationActivity
+    Git_repo: https://github.com/microbiomedata/mg_annotation
+    Version: v1.1.0
+    Collection: metatranscriptome_annotation_set
+    ActivityRange: MetatranscriptomeAnnotationActivity
+    Inputs:
+      - Assembly Contigs
+    Activity:
+      name: "Metatranscriptome Annotation Analysis Activity for {id}"
+      type: nmdc:MetatranscriptomeAnnotationActivity
+    Outputs:
+      - Annotation Amino Acid FASTA
+      - Structural Annotation GFF
+      - Functional Annotation GFF
+      - Annotation KEGG Orthology
+      - Annotation Enzyme Commission
+      - Scaffold Lineage tsv
+      - Clusters of Orthologous Groups (COG) Annotation GFF
+      - Pfam Annotation GFF
+      - TIGRFam Annotation GFF
+      - SMART Annotation GFF
+      - SUPERFam Annotation GFF
+      - CATH FunFams (Functional Families) Annotation GFF
+      - CRT Annotation GFF
+      - Genmark Annotation GFF
+      - Prodigal Annotation GFF
+      - TRNA Annotation GFF
+      - RFAM Annotation GFF
+      - KO_EC Annotation GFF
+      - Product Names
+      - Gene Phylogeny tsv
+      - Crisprt Terms
+      - Annotation Statistics
+      - Contig Mapping File
+      - Annotation Info File
+      - Assembly Contigs
+
+
+  - Name: Expression Analysis Generic
+    Import: false
+    Type: nmdc:MetatranscriptomeExpressionAnalysis
+    Git_repo: https://github.com/microbiomedata/metaT_ReadCounts
+    Version: v0.0.1
+    Collection: metatranscriptome_expression_analysis_set
+    ActivityRange: MetatranscriptomeExpressionAnalysis
+    Inputs:
+      - Functional Annotation GFF
+      - Contig Mapping File
+      - Assembly Coverage BAM
+    Activity:
+      name: "Metatranscriptome Expression Analysis for {id}"
+      type: nmdc:MetatranscriptomeExpressionAnalysis
+    Outputs:
+      - Metatranscriptome Expression 
+      - Metatranscriptome Expression Intergenic
+
+Data Objects:
+  Unique:
+    - data_object_type: Metagenome Raw Reads
+      description: Metagenome Raw Reads for {id}
+      name: Raw sequencer read data
+      import_suffix: .[A-Z]+-[A-Z]+.fastq.gz
+      nmdc_suffix: .fastq.gz
+      input_to: [nmdc:ReadQcAnalysisActivity]
+      output_of: nmdc:MetagenomeSequencingActivity
+      mulitple: false
+      action: none
+    - data_object_type: Annotation Amino Acid FASTA
+      description: FASTA Amino Acid File for {id}
+      name: FASTA amino acid file for annotated proteins
+      import_suffix: _proteins.faa
+      nmdc_suffix: _proteins.faa
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: Contig Mapping File
+      description: Contig mapping file for {id}
+      name: Contig mappings between old and new contig names
+      import_suffix: _contig_names_mapping.tsv
+      nmdc_suffix: _contig_names_mapping.tsv
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: Structural Annotation GFF
+      description: Structural Annotation for {id}
+      name: GFF3 format file with structural annotations
+      import_suffix: _structural_annotation.gff
+      nmdc_suffix: _structural_annotation.gff
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: Functional Annotation GFF
+      description: Functional Annotation for {id}
+      name: GFF3 format file with functional annotations
+      import_suffix: _functional_annotation.gff
+      nmdc_suffix: _functional_annotation.gff
+      input_to: [nmdc:MetatranscriptomeExpressionAnalysis]
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: Annotation KEGG Orthology
+      description: KEGG Orthology for {id}
+      name: Tab delimited file for KO annotation
+      import_suffix: _ko.tsv
+      nmdc_suffix: _ko.tsv
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: Annotation Enzyme Commission
+      description: EC Annotations for {id}
+      name: Tab delimited file for EC annotation
+      import_suffix: _ec.tsv
+      nmdc_suffix: _ec.tsv
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type Scaffold Lineage tsv
+      description: Scaffold Lineage tsv for {id}
+      name: Phylogeny at the scaffold level
+      import_suffix: _scaffold_lineage.tsv
+      nmdc_suffix: _scaffold_lineage.tsv
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+    - data_object_type: Clusters of Orthologous Groups (COG) Annotation GFF
+      description: COGs for {id}
+      name: GFF3 format file with COGs
+      import_suffix: _cog.gff
+      nmdc_suffix: _cog.gff
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: Pfam Annotation GFF
+      description: Pfam Annotation for {id}
+      name: GFF3 format file with Pfam
+      import_suffix: _pfam.gff
+      nmdc_suffix: _pfam.gff
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: TIGRFam Annotation GFF
+      description: TIGRFam for {id}
+      name: GFF3 format file with TIGRfam
+      import_suffix: _tigrfam.gff
+      nmdc_suffix: _tigrfam.gff
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: SMART Annotation GFF
+      description: SMART Annotations for {id}
+      name: GFF3 format file with SMART
+      import_suffix: _smart.gff
+      nmdc_suffix: _smart.gff
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: SUPERFam Annotation GFF
+      description: SUPERFam Annotations for {id}
+      name: GFF3 format file with SUPERFam
+      import_suffix: _supfam.gff
+      nmdc_suffix: _supfam.gff
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: CATH FunFams (Functional Families) Annotation GFF
+      description: CATH FunFams for {id}
+      name: GFF3 format file with CATH FunFams
+      import_suffix: _cath_funfam.gff
+      nmdc_suffix: _cath_funfam.gff
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: CRT Annotation GFF
+      description: CRT Annotations for {id}
+      name: GFF3 format file with CRT
+      import_suffix: _crt.gff
+      nmdc_suffix: _crt.gff
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: Genemark Annotation GFF
+      description: Genemark Annotations for {id}
+      name: GFF3 format file with Genemark
+      import_suffix: _genemark.gff
+      nmdc_suffix: _genemark.gff
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: Prodigal Annotation GFF
+      description: Prodigal Annotations {id}
+      name: GFF3 format file with Prodigal
+      import_suffix: _prodigal.gff
+      nmdc_suffix: _prodigal.gff
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: TRNA Annotation GFF
+      description: TRNA Annotations {id}
+      name: GFF3 format file with TRNA
+      import_suffix: _trna.gff
+      nmdc_suffix: _trna.gff
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: RFAM Annotation GFF
+      description: RFAM Annotations for {id}
+      name: GFF3 format file with RFAM
+      import_suffix: _rfam.gff
+      nmdc_suffix: _rfam.gff
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: KO_EC Annotation GFF
+      description: KO_EC Annotations for {id}
+      name: GFF3 format file with KO_EC
+      import_suffix: _ko_ec.gff
+      nmdc_suffix: _ko_ec.gff
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: Product Names
+      description: Product names for {id}
+      name: Product names file
+      import_suffix: _product_names.tsv
+      nmdc_suffix: _product_names.tsv
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: Gene Phylogeny tsv
+      description: Gene Phylogeny for {id}
+      name: Gene Phylogeny file
+      import_suffix: _gene_phylogeny.tsv
+      nmdc_suffix: _gene_phylogeny.tsv
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: Crispr Terms
+      description: Crispr Terms for {id}
+      name: Crispr Terms
+      import_suffix: _crt.crisprs
+      nmdc_suffix: _crt.crisprs
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: Annotation Statistics
+      description: Annotation Stats for {id}
+      name: Annotation statistics report
+      import_suffix: _stats.tsv
+      nmdc_suffix: _stats.tsv
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: Annotation Info File
+      description: Annotation Info File for {id}
+      name: File containing annotation info
+      import_suffix: _imgap.info
+      nmdc_suffix: _imgap.info
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false
+      action: rename
+    - data_object_type: Assembly Contigs
+      description: Assembly contigs (remapped) for {id}
+      import_suffix: _contigs.fna 
+      nmdc_suffix: _renamed_contigs.fna
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAnnotationActivity
+      mulitple: false 
+    - data_object_type: Filtered Sequencing Reads
+      description: Reads QC for {id}
+      name: Reads QC result fastq (clean data)
+      import_suffix: filter-MTF.fastq.gz
+      nmdc_suffix: _filtered.fastq.gz
+      input_to: [nmdc:MetatranscriptomeAssembly]
+      output_of: nmdc:ReadQcAnalysisActivity
+      mulitple: false
+      action: rename
+    - data_object_type: rRNA Filtered Sequencing Reads
+      description: Reads QC rRNA reads file for {id}
+      name: Reads QC rRNA reads  result fastq (clean data)
+      import_suffix: .rRNA.fastq.gz
+      nmdc_suffix: _rRNA.fastq.gz
+      input_to: []
+      output_of: nmdc:ReadQcAnalysisActivity
+      mulitple: false
+      action: rename
+    - data_object_type: QC Statistics 
+      description: Reads QC summary for {id} 
+      name: Reads QC summary statistics
+      import_suffix: .filtered-report.txt
+      nmdc_suffix: _filterStats.txt
+      input_to: []
+      output_of: nmdc:ReadQcAnalysisActivity
+      mulitple: false
+      action: rename
+    - data_object_type: Read Filtering Info File 
+      description: Read Filtering Info File for {id}
+      name: File containing read filtering information
+      import_suffix: .filter_cmd-MTF.sh
+      nmdc_suffix: _readsQC.info
+      input_to: []
+      output_of: nmdc:ReadQcAnalysisActivity
+      mulitple: false
+      action: rename
+    - data_object_type: Assembly Contigs
+      description: Assembly contigs for {id}
+      name: Final assembly contigs fasta
+      import_suffix: assembly.contigs.fasta
+      nmdc_suffix: _contigs.fna
+      input_to: [nmdc:MetatranscriptomeAnnotationActivity]
+      output_of: nmdc:MetatranscriptomeAssembly
+      mulitple: false
+      action: rename
+    - data_object_type: Assembly Info File
+      description: Assembly info file for {id}
+      name: File containing assembly information
+      import_suffix: README.txt
+      nmdc_suffix: _metaAsm.info
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAssembly
+      mulitple: false
+      action: rename
+    - data_object_type: Assembly Coverage Stats
+      description: Coverage Stats for {id}
+      name: Assembled contigs coverage information
+      import_suffix: pairedMapped_sorted.bam.cov
+      nmdc_suffix: _covstats.txt
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAssembly
+      mulitple: false
+      action: rename
+    - data_object_type: Assembly Coverage BAM
+      description: Sorted Bam for {id}
+      name: Sorted bam file of reads mapping back to the final assembly
+      import_suffix: pairedMapped.bam.gz
+      nmdc_suffix: _pairedMapped_sorted.bam.gz
+      input_to: [nmdc:MetatranscriptomeExpressionAnalysis]
+      output_of: nmdc:MetatranscriptomeAssembly
+      mulitple: false
+      action: rename
+    - data_object_type: BAI File
+      description: Alignment index file for {id}
+      name: BAM index file
+      import_suffix: _pairedMapped_sorted.bam.bai
+      nmdc_suffix: _pairedMapped_sorted.bam.bai
+      input_to: []
+      output_of: nmdc:MetatranscriptomeAssembly
+      mulitple: false
+      action: rename
+    - data_object_type: Metatranscriptome Expression
+      description: Expression counts for {id}
+      name: Expression counts file
+      import_suffix: .rnaseq_gea.txt
+      nmdc_suffix: _rnaseq_gea.txt
+      input_to: []
+      output_of: nmdc:MetatranscriptomeExpressionAnalysis
+      mulitple: false
+      action: rename
+    - data_object_type: Metatranscriptome Expression Intergenic
+      description: Expression intergenic counts for {id}
+      name: Expression intergenic counts file
+      import_suffix: .rnaseq_gea.intergenic.txt
+      nmdc_suffix: _rnaseq_gea.intergenic.txt
+      input_to: []
+      output_of: nmdc:MetatranscriptomeExpressionAnalysis
+      mulitple: false
+      action: rename
+
+
+Workflow Metadata:
+  Execution Resource: JGI
+  Source URL: https://data.microbiomedata.org/data
+  Root Directory: /global/cfs/cdirs/m3408/ficus/pipeline_products

--- a/configs/import-mt.yaml
+++ b/configs/import-mt.yaml
@@ -1,22 +1,9 @@
 Workflows:
-  - Name: Sequencing
-    Import: true
-    Type: nmdc:MetagenomeSequencingActivity
-    Git_repo: https://github.com/microbiomedata/RawSequencingData
-    Version: v1.0.0
-    Collection: metagenome_sequencing_activity_set
-    ActivityRange: MetagenomeSequencingActivity
-    Activity:
-      name: "Metagenome Sequencing Activity for {id}"
-      type: nmdc:MetagenomeSequencingActivity
-    Outputs:
-      - Metagenome Raw Reads
-
   - Name: Metatranscriptome Reads QC
     Import: true
     Type: nmdc:ReadQcAnalysisActivity
     Git_repo: https://github.com/microbiomedata/metaT_ReadsQC
-    Version: v0.0.3
+    Version: v0.0.7
     Collection: read_qc_analysis_activity_set
     ActivityRange: ReadQcAnalysisActivity
     Inputs:
@@ -38,7 +25,7 @@ Workflows:
     Import: false
     Type: nmdc:MetatranscriptomeAssembly
     Git_repo: https://github.com/microbiomedata/metaT_Assembly
-    Version: v0.0.1
+    Version: v0.0.2
     Collection: metatranscriptome_assembly_set
     ActivityRange: MetatranscriptomeAssembly
     Inputs:
@@ -82,7 +69,7 @@ Workflows:
     Import: false
     Type: nmdc:MetatranscriptomeAnnotationActivity
     Git_repo: https://github.com/microbiomedata/mg_annotation
-    Version: v1.1.0
+    Version: v1.1.4
     Collection: metatranscriptome_annotation_set
     ActivityRange: MetatranscriptomeAnnotationActivity
     Inputs:
@@ -122,7 +109,7 @@ Workflows:
     Import: false
     Type: nmdc:MetatranscriptomeExpressionAnalysis
     Git_repo: https://github.com/microbiomedata/metaT_ReadCounts
-    Version: v0.0.1
+    Version: v0.0.5
     Collection: metatranscriptome_expression_analysis_set
     ActivityRange: MetatranscriptomeExpressionAnalysis
     Inputs:

--- a/configs/import-mt.yaml
+++ b/configs/import-mt.yaml
@@ -131,7 +131,7 @@ Data Objects:
       import_suffix: .[A-Z]+-[A-Z]+.fastq.gz
       nmdc_suffix: .fastq.gz
       input_to: [nmdc:ReadQcAnalysisActivity]
-      output_of: nmdc:MetagenomeSequencingActivity
+      output_of: nmdc:OmicsProcessing
       mulitple: false
       action: none
     - data_object_type: Annotation Amino Acid FASTA

--- a/configs/workflows-mt.yaml
+++ b/configs/workflows-mt.yaml
@@ -106,7 +106,7 @@ Workflows:
     Git_repo: https://github.com/microbiomedata/metaT_Assembly
     Version: v0.0.1
     WDL: metaT_assembly.wdl
-    Collection: metagenome_assembly_set
+    Collection: metatranscriptome_assembly_set
     Predecessors:
     - Metatranscriptome Reads QC
     - Metatranscriptome Reads QC Interleave


### PR DESCRIPTION
This PR addes a new yaml config, import-mt.yaml, that defines DataObjects and WorkflowExecutionActivites to be made when ingesting existing records from JGI. It also fixes a typo in the collection for assembly for workflows-mt.yaml