### PR TITLE
Update data object types in  import.yaml

### DIFF
--- a/configs/import.yaml
+++ b/configs/import.yaml
@@ -574,7 +574,7 @@ Data Objects:
       mulitple: false
       action: rename
   Multiples:
-    - data_object_type: Metagenome Bins
+    - data_object_type: Metagenome HQMQ Bins Compression File
       description: Metagenome Bins for {id}
       name: Metagenome bin tarfiles archive
       import_suffix: _[0-9]+.tar.gz


### PR DESCRIPTION
This PR updates the data_object_type of the zip file containing medium and high quality bins. None of the other new data_object_type's described in https://github.com/microbiomedata/nmdc_automation/issues/67 pertain to ingest.