### PR TITLE
Increment metaAssembly version to v1.0.7

### DIFF
--- a/configs/import.yaml
+++ b/configs/import.yaml
@@ -46,7 +46,7 @@ Workflows:
     Import: true
     Type: nmdc:MetagenomeAssembly
     Git_repo: https://github.com/microbiomedata/metaAssembly
-    Version: v1.0.3
+    Version: v1.0.7
     Collection: workflow_execution_set
     WorkflowExecutionRange: MetagenomeAssembly
     Inputs:

--- a/nmdc_automation/config/workflows/workflows.yaml
+++ b/nmdc_automation/config/workflows/workflows.yaml
@@ -95,7 +95,7 @@ Workflows:
     Enabled: True
     Analyte Category: Metagenome
     Git_repo: https://github.com/microbiomedata/metaAssembly
-    Version: v1.0.3
+    Version: v1.0.7
     WDL: jgi_assembly.wdl
     Collection: workflow_execution_set
     Predecessors:


### PR DESCRIPTION
Updates MetaAssembly version to v1.0.7 in:

- workflows.yaml
- import.yaml