### PR TITLE
Cache results of `allowed_workflows`

### DIFF
--- a/nmdc_automation/config/siteconfig.py
+++ b/nmdc_automation/config/siteconfig.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 import tomli
 from typing import Union
 import yaml
@@ -98,6 +99,7 @@ class SiteConfig:
         return self.config_data["credentials"]["client_secret"]
 
     @property
+    @lru_cache(maxsize=None)
     def allowed_workflows(self):
         """Generate a list of allowed workflows."""
         workflows_config_file = self.config_data["workflows"]["workflows_config"]


### PR DESCRIPTION
This PR addresses a stale file-handle error, which in turn cause the Watcher daemon to exit:
```
2024-11-19 12:40:33,557 INFO: Restored 0 jobs from state
2024-11-19 12:40:33,561 ERROR: Error occurred during cycle: [Errno 116] Stale file handle: '/global/homes/n/nmdcda/nmdc_automation/dev/nmdc_automation/nmdc_automation/config/workflows/workflows.yaml'
Traceback (most recent call last):
  File "/global/homes/n/nmdcda/nmdc_automation/dev/nmdc_automation/nmdc_automation/workflow_automation/watch_nmdc.py", line 360, in watch
  File "/global/homes/n/nmdcda/nmdc_automation/dev/nmdc_automation/nmdc_automation/workflow_automation/watch_nmdc.py", line 318, in cycle
  File "/global/homes/n/nmdcda/nmdc_automation/dev/nmdc_automation/nmdc_automation/config/siteconfig.py", line 104, in allowed_workflows
OSError: [Errno 116] Stale file handle: '/global/homes/n/nmdcda/nmdc_automation/dev/nmdc_automation/nmdc_automation/config/workflows/workflows.yaml'
``` 

The fix here is to cache the results of reading in `workflows.yaml` in the `allowed_workflows` function