### PR TITLE
291 error initializing scheduler on spin

### DIFF
--- a/nmdc_automation/workflow_automation/workflow_process.py
+++ b/nmdc_automation/workflow_automation/workflow_process.py
@@ -26,7 +26,7 @@ def get_required_data_objects_map(db, workflows: List[WorkflowConfig]) -> Dict[s
         required_types.update(set(wf.data_object_types))
 
     required_data_objs_by_id = dict()
-    for rec in db.data_object_set.find():
+    for rec in db.data_object_set.find({"data_object_type": {"$ne": None}}):
         do = DataObject(**rec)
         if do.data_object_type.code.text not in required_types:
             continue

--- a/tests/fixtures/nmdc_db/data_object_set.json
+++ b/tests/fixtures/nmdc_db/data_object_set.json
@@ -815,5 +815,15 @@
     "data_object_type": "Metatranscriptome Expression Info File",
     "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject"
-  }
+  },
+  {
+    "id" : "nmdc:dobj-13-zzzyae97",
+    "name" : "output: SBR_FC_N1_00-10_H2Oext_13Oct15_Leopard_1_01_4404",
+    "description" : "High resolution MS spectra only",
+    "file_size_bytes" : 30539306,
+    "type" : "nmdc:DataObject",
+    "alternative_identifiers" : [
+        "emsl:output_456424"
+    ]
+}
 ]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -118,7 +118,9 @@ def test_data_object_creation_from_records(fixtures_dir):
         assert data_obj.type == "nmdc:DataObject"
         assert data_obj.id == record["id"]
         assert data_obj.name == record["name"]
-        assert str(data_obj.data_object_type) == record["data_object_type"]
+        # not all data objects have a data_object_type - e.g. Mass Spectrometry data
+        if "data_object_type" in record:
+            assert str(data_obj.data_object_type) == record["data_object_type"]
 
         data_obj_dict = yaml.safe_load(yaml_dumper.dumps(data_obj))
         assert data_obj_dict == record
@@ -136,9 +138,12 @@ def test_data_object_creation_from_db_records(test_db, fixtures_dir):
         assert data_obj.type == "nmdc:DataObject"
         assert data_obj.id == db_record["id"]
         assert data_obj.name == db_record["name"]
+        # not all data objects have a data_object_type or url - e.g. Mass Spectrometry data
+        if not db_record.get("data_object_type"):
+            continue
         assert str(data_obj.data_object_type) == db_record["data_object_type"]
-        assert data_obj.description == db_record["description"]
         assert data_obj.url == db_record["url"]
+        assert data_obj.description == db_record["description"]
         assert data_obj.file_size_bytes == db_record.get("file_size_bytes")
         assert data_obj.md5_checksum == db_record["md5_checksum"]
 


### PR DESCRIPTION
This PR provides a fix for:

#291 

Error:
```
File "/src/nmdc_automation/workflow_automation/workflow_process.py", line 31, in get_required_data_objects_map
    if do.data_object_type.code.text not in required_types:
AttributeError: 'NoneType' object has no attribute 'code'
``` 

`get_required_data_objects_map` was doing a find on the data_object_set with no filters.  Some data objects do not have a data_object_type, which led to the AttributeError

Fix is to filter out data objects without a type