### PR TITLE
293 scheduler not handling nmdc:MetagenomeSequencing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ This package is meant to be used on NMDC approvied compute instances with direct
 
 The main python drivers can be found in the `nmdc_automation/run_process directory` that contians two processes that require configurations to be supplied. 
  
+### Managing Workflow Updates
+
+Incorporating updated workflow versions into nmdc_automation is a manual process. 
+
+1. Update the workflows.yaml file with the new workflow version.
+2. Merge the updated workflows.yaml file into the main branch.
+3. Build the docker image and push it to the docker registry.
+    ```bash
+   docker build -t microbiomedata/sched:<yyyymmdd> .
+   docker login
+    docker push microbiomedata/sched:<yyyymmdd>
+   ```
+4. Update the docker image in the nmdc-automation deployment in the rancher UI.
+5. Restart the nmdc-automation deployment in the rancher UI.
+
 #### Run NMDC Workflows with corresponding omics processing records
 ~~`nmdc_automation/run_process/run_worklfows.py` will automate job claims, job processing, and analysis record and data object submission via the nmdc runtime-api.~~
 ~~To submit a process that will spawn a daemon that will claim, process, and submit all jobs that have not been claimed, `cd` in to `nmdc_automation/run_process`

--- a/nmdc_automation/config/workflows/workflows.yaml
+++ b/nmdc_automation/config/workflows/workflows.yaml
@@ -14,6 +14,13 @@ Workflows:
     Filter Output Objects:
     - Metagenome Raw Reads
 
+  - Name: Metagenome Sequencing
+    Collection: workflow_execution_set
+    Enabled: True
+    Analyte Category: Metagenome
+    Filter Output Objects:
+    - Metagenome Raw Reads
+
   - Name: Reads QC
     Type: nmdc:ReadQcAnalysis
     Enabled: True
@@ -26,6 +33,7 @@ Workflows:
     - Metagenome Raw Reads
     Predecessors:
     - Sequencing Interleaved
+    - Metagenome Sequencing
     Input_prefix: nmdc_rqcfilter
     Inputs:
       input_files: do:Metagenome Raw Reads

--- a/nmdc_automation/models/nmdc.py
+++ b/nmdc_automation/models/nmdc.py
@@ -9,9 +9,20 @@ from linkml_runtime.dumpers import yaml_dumper
 import yaml
 
 
-from nmdc_schema.nmdc import DataGeneration, FileTypeEnum, MagsAnalysis, MetagenomeAnnotation, MetagenomeAssembly, \
-    MetatranscriptomeAnnotation, MetatranscriptomeAssembly, MetatranscriptomeExpressionAnalysis, NucleotideSequencing, \
-    ReadBasedTaxonomyAnalysis, ReadQcAnalysis, WorkflowExecution
+from nmdc_schema.nmdc import (
+    DataGeneration,
+    MagsAnalysis,
+    MetagenomeAnnotation,
+    MetagenomeAssembly,
+    MetagenomeSequencing,
+    MetatranscriptomeAnnotation,
+    MetatranscriptomeAssembly,
+    MetatranscriptomeExpressionAnalysis,
+    NucleotideSequencing,
+    ReadBasedTaxonomyAnalysis,
+    ReadQcAnalysis,
+    WorkflowExecution
+)
 import nmdc_schema.nmdc as nmdc
 
 
@@ -32,6 +43,7 @@ WorkflowExecution]:
         "nmdc:MagsAnalysis": MagsAnalysis,
         "nmdc:MetagenomeAnnotation": MetagenomeAnnotation,
         "nmdc:MetagenomeAssembly": MetagenomeAssembly,
+        "nmdc:MetagenomeSequencing": MetagenomeSequencing,
         "nmdc:MetatranscriptomeAnnotation": MetatranscriptomeAnnotation,
         "nmdc:MetatranscriptomeAssembly": MetatranscriptomeAssembly,
         "nmdc:MetatranscriptomeExpressionAnalysis": MetatranscriptomeExpressionAnalysis,

--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -294,12 +294,15 @@ class Scheduler:
         self.get_existing_jobs.cache_clear()
         job_recs = []
         for wfp_node in wfp_nodes:
+            # Skip if we are in the skiplist
             if wfp_node.was_informed_by in skiplist:
                 logging.debug(f"Skipping: {wfp_node.was_informed_by}")
                 continue
+            # Skip if the workflow is disabled
             if not wfp_node.workflow.enabled:
                 logging.debug(f"Skipping: {wfp_node.id}, workflow disabled.")
                 continue
+            # Find new jobs
             jobs = self.find_new_jobs(wfp_node)
             for job in jobs:
                 if dryrun:

--- a/tests/fixtures/nmdc_db/data_object_set.json
+++ b/tests/fixtures/nmdc_db/data_object_set.json
@@ -825,5 +825,16 @@
     "alternative_identifiers" : [
         "emsl:output_456424"
     ]
+},
+  {
+    "id" : "nmdc:dobj-11-7ag1m391",
+    "name" : "52818.3.460102.GTGGTGTT-GTGGTGTT.fastq.gz",
+    "description" : "Metagenome Raw Reads for nmdc:omprc-11-3rnpg083",
+    "alternative_identifiers" : [],
+    "file_size_bytes" : 35395496786,
+    "md5_checksum" : "7f3fd94c01fcece0806a739365441a4b",
+    "data_object_type" : "Metagenome Raw Reads",
+    "url" : "https://data.microbiomedata.org/data/nmdc:omprc-11-3rnpg083/nmdc:wfmsa-11-9ehf1814.1/52818.3.460102.GTGGTGTT-GTGGTGTT.fastq.gz",
+    "type" : "nmdc:DataObject"
 }
 ]

--- a/tests/fixtures/nmdc_db/data_object_set.json
+++ b/tests/fixtures/nmdc_db/data_object_set.json
@@ -830,7 +830,6 @@
     "id" : "nmdc:dobj-11-7ag1m391",
     "name" : "52818.3.460102.GTGGTGTT-GTGGTGTT.fastq.gz",
     "description" : "Metagenome Raw Reads for nmdc:omprc-11-3rnpg083",
-    "alternative_identifiers" : [],
     "file_size_bytes" : 35395496786,
     "md5_checksum" : "7f3fd94c01fcece0806a739365441a4b",
     "data_object_type" : "Metagenome Raw Reads",

--- a/tests/fixtures/nmdc_db/metagenome_sequencing.json
+++ b/tests/fixtures/nmdc_db/metagenome_sequencing.json
@@ -1,4 +1,5 @@
-{
+[
+    {
     "id" : "nmdc:wfmsa-11-9ehf1814.1",
     "name" : "Metagenome Sequencing Activity for nmdc:wfmsa-11-9ehf1814.1",
     "started_at_time" : "2023-09-13T20:42:20.564800+00:00",
@@ -15,3 +16,4 @@
     "type" : "nmdc:MetagenomeSequencing",
     "version" : "v1.0.0"
 }
+]

--- a/tests/fixtures/nmdc_db/metagenome_sequencing.json
+++ b/tests/fixtures/nmdc_db/metagenome_sequencing.json
@@ -1,0 +1,17 @@
+{
+    "id" : "nmdc:wfmsa-11-9ehf1814.1",
+    "name" : "Metagenome Sequencing Activity for nmdc:wfmsa-11-9ehf1814.1",
+    "started_at_time" : "2023-09-13T20:42:20.564800+00:00",
+    "ended_at_time" : "2023-09-13T20:42:20.564814+00:00",
+    "was_informed_by" : "nmdc:omprc-11-3rnpg083",
+    "execution_resource" : "JGI",
+    "git_url" : "https://github.com/microbiomedata/RawSequencingData",
+    "has_input" : [
+        "nmdc:procsm-11-wzbyx612"
+    ],
+    "has_output" : [
+        "nmdc:dobj-11-7ag1m391"
+    ],
+    "type" : "nmdc:MetagenomeSequencing",
+    "version" : "v1.0.0"
+}


### PR DESCRIPTION
This PR provides a fix for #293 

Root cause of the error was failure to handle `nmdc:MetagenomeSequencing` workflow executions correctly.

Changes in this PR
- update `workflow_process.py` to correctly handle Metagenome Sequencing as a sort-of data generation
- update workflows.yaml with new workflow
- update models.nmdc workflow_process_factory to handle the type
- unit tests for workflow_process and scheduler.cycle
- new test fixtures