### PR TITLE
remove the local testing allow list override

### DIFF
--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -335,8 +335,6 @@ def main(site_conf, wf_file):  # pragma: no cover
         with open(os.environ.get("ALLOWLISTFILE")) as f:
             for line in f:
                 allowlist.add(line.rstrip())
-    # for local testing
-    allowlist = ["nmdc:omprc-13-01jx8727"]
     while True:
         sched.cycle(dryrun=dryrun, skiplist=skiplist, allowlist=allowlist)
         if dryrun:


### PR DESCRIPTION
This PR fixes #309 
Issue was a line in `sched.main` that would over-ride the allow-list value.  This PR removes it