### PR TITLE
Always update job metadata in process_successful_job

### DIFF
--- a/nmdc_automation/workflow_automation/watch_nmdc.py
+++ b/nmdc_automation/workflow_automation/watch_nmdc.py
@@ -236,14 +236,13 @@ class JobManager:
 
         database = Database()
 
-        # get job runner metadata if needed
-        if not job.job.metadata:
-            logger.info(f"Getting job runner metadata for job {job.workflow.job_runner_id}")
-            job.job.job_id = job.workflow.job_runner_id
-            metadata = job.job.get_job_metadata()
-            m_dict = yaml.safe_load(yaml_dumper.dumps(metadata))
-            logger.debug(f"Job runner metadata: {m_dict}")
-            job.job.metadata = metadata
+        # Upate the job metadata
+        logger.info(f"Getting job runner metadata for job {job.workflow.job_runner_id}")
+        job.job.job_id = job.workflow.job_runner_id
+        metadata = job.job.get_job_metadata()
+        m_dict = yaml.safe_load(yaml_dumper.dumps(metadata))
+        logger.debug(f"Job runner metadata: {m_dict}")
+        job.job.metadata = metadata
 
         data_objects = job.make_data_objects(output_dir=output_path)
         if not data_objects:


### PR DESCRIPTION
This PR addresses #315 

The sequence of log messages:
```
2024-12-04 00:00:00,504 INFO: Found 1 successful jobs.
2024-12-04 00:00:00,504 INFO: Processing successful job: nmdc:sys0sc99je06, nmdc:wfmgan-12-z1vfrs19.1
2024-12-04 00:00:00,504 INFO: Process successful job:  nmdc:sys0sc99je06
2024-12-04 00:00:00,736 INFO: Processing output annotation.proteins_faa
``` 
Show that the optional step to update job metadata had been skipped based on the `if` condition.  This PR makes updating the metadata for a successful job non-optional