### PR TITLE
326 data object descriptions not being populated correctly

### DIFF
--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -537,7 +537,8 @@ class WorkflowJob:
             data_object = DataObject(
                 id=output_spec["id"], name=output_file_path.name, type="nmdc:DataObject", url=file_url,
                 data_object_type=output_spec["data_object_type"], md5_checksum=md5_sum,
-                description=output_spec["description"], was_generated_by=self.workflow_execution_id, )
+                description=output_spec["description"].replace('{id}', self.workflow_execution_id),
+                was_generated_by=self.workflow_execution_id, )
 
             data_objects.append(data_object)
         return data_objects

--- a/tests/test_wfutils.py
+++ b/tests/test_wfutils.py
@@ -320,6 +320,18 @@ def test_workflow_execution_record_from_workflow_job(site_config, fixtures_dir, 
     assert wfe.ended_at_time
 
 
+def test_make_data_objects_substutes_workflow_id(site_config, fixtures_dir, tmp_path):
+    job_metadata = json.load(open(fixtures_dir / "mags_job_metadata.json"))
+    workflow_state = json.load(open(fixtures_dir / "mags_workflow_state.json"))
+    job = WorkflowJob(site_config, workflow_state, job_metadata)
+    data_objects = job.make_data_objects(output_dir=tmp_path)
+    assert data_objects
+    for data_object in data_objects:
+        assert isinstance(data_object, DataObject)
+        assert job.workflow_execution_id in data_object.description
+
+
+
 
 def test_workflow_job_from_database_job_record(site_config, fixtures_dir):
     job_rec = json.load(open(fixtures_dir / "nmdc_api/unsubmitted_job.json"))


### PR DESCRIPTION
This PR provides a fix for workflow execution ID missing from Data Object description:
- adds a unit test to replicate the failure
- updates `make_data_objects` to sub ID into description