### PR TITLE
add retry decorator to api methods

### DIFF
--- a/nmdc_automation/run_process/run_import.py
+++ b/nmdc_automation/run_process/run_import.py
@@ -13,7 +13,7 @@ from nmdc_automation.import_automation import GoldMapper
 from nmdc_automation.api import NmdcRuntimeApi
 
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 

--- a/nmdc_automation/workflow_automation/watch_nmdc.py
+++ b/nmdc_automation/workflow_automation/watch_nmdc.py
@@ -12,6 +12,7 @@ import linkml.validator
 import importlib.resources
 from functools import lru_cache
 import traceback
+import os
 
 from nmdc_schema.nmdc import Database
 from nmdc_automation.api import NmdcRuntimeApi
@@ -23,8 +24,12 @@ from nmdc_automation.workflow_automation.wfutils import WorkflowJob
 DEFAULT_STATE_DIR = Path(__file__).parent / "_state"
 DEFAULT_STATE_FILE = DEFAULT_STATE_DIR / "state.json"
 INITIAL_STATE = {"jobs": []}
+
+logging_level = os.getenv("NMDC_LOG_LEVEL", logging.DEBUG)
+logging.basicConfig(
+    level=logging_level, format="%(asctime)s %(levelname)s: %(message)s"
+)
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class FileHandler:

--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -22,6 +22,11 @@ from nmdc_automation.models.nmdc import DataObject, WorkflowExecution, workflow_
 
 DEFAULT_MAX_RETRIES = 2
 
+logging_level = os.getenv("NMDC_LOG_LEVEL", logging.DEBUG)
+logging.basicConfig(
+    level=logging_level, format="%(asctime)s %(levelname)s: %(message)s"
+)
+logger = logging.getLogger(__name__)
 
 class JobRunnerABC(ABC):
     """Abstract base class for job runners"""
@@ -132,7 +137,7 @@ class CromwellRunner(JobRunnerABC):
                 "workflowInputs": open(_json_tmp(self._generate_workflow_inputs()), "rb"),
                 "labels": open(_json_tmp(self._generate_workflow_labels()), "rb"), }
         except Exception as e:
-            logging.error(f"Failed to generate submission files: {e}")
+            logger.error(f"Failed to generate submission files: {e}")
             self._cleanup_files(list(files.values()))
             raise e
         return files
@@ -144,7 +149,7 @@ class CromwellRunner(JobRunnerABC):
                 file.close()
                 os.unlink(file.name)
             except Exception as e:
-                logging.error(f"Failed to cleanup file: {e}")
+                logger.error(f"Failed to cleanup file: {e}")
 
     def submit_job(self, force: bool = False) -> Optional[str]:
         """
@@ -154,7 +159,7 @@ class CromwellRunner(JobRunnerABC):
         """
         status = self.workflow.last_status
         if status in self.NO_SUBMIT_STATES and not force:
-            logging.info(f"Job {self.job_id} in state {status}, skipping submission")
+            logger.info(f"Job {self.job_id} in state {status}, skipping submission")
             return
         cleanup_files = []
         try:
@@ -165,12 +170,12 @@ class CromwellRunner(JobRunnerABC):
                 response.raise_for_status()
                 self.metadata = response.json()
                 self.job_id = self.metadata["id"]
-                logging.info(f"Submitted job {self.job_id}")
+                logger.info(f"Submitted job {self.job_id}")
             else:
-                logging.info(f"Dry run: skipping job submission")
+                logger.info(f"Dry run: skipping job submission")
                 self.job_id = "dry_run"
 
-            logging.info(f"Job {self.job_id} submitted")
+            logger.info(f"Job {self.job_id} submitted")
             start_time = datetime.now(pytz.utc).isoformat()
             # update workflow state
             self.workflow.done = False
@@ -179,7 +184,7 @@ class CromwellRunner(JobRunnerABC):
             self.workflow.update_state({"last_status": "Submitted"})
             return self.job_id
         except Exception as e:
-            logging.error(f"Failed to submit job: {e}")
+            logger.error(f"Failed to submit job: {e}")
             raise e
         finally:
             self._cleanup_files(cleanup_files)
@@ -191,7 +196,7 @@ class CromwellRunner(JobRunnerABC):
         status_url = f"{self.service_url}/{self.workflow.cromwell_jobid}/status"
         # There can be a delay between submitting a job and it
         # being available in Cromwell so handle 404 errors
-        logging.debug(f"Getting job status from {status_url}")
+        logger.debug(f"Getting job status from {status_url}")
         try:
             response = requests.get(status_url)
             response.raise_for_status()
@@ -355,9 +360,9 @@ class WorkflowStateManager:
         Download a release file from the Git repository and save it as a temporary file.
         Note: the temporary file is not deleted automatically.
         """
-        logging.debug(f"Fetching release file: {filename}")
+        logger.debug(f"Fetching release file: {filename}")
         url = self._build_release_url(filename)
-        logging.debug(f"Fetching release file from URL: {url}")
+        logger.debug(f"Fetching release file from URL: {url}")
         # download the file as a stream to handle large files
         response = requests.get(url, stream=True)
         try:
@@ -371,9 +376,9 @@ class WorkflowStateManager:
 
     def _build_release_url(self, filename: str) -> str:
         """Build the URL for a release file in the Git repository."""
-        logging.debug(f"Building release URL for {filename}")
+        logger.debug(f"Building release URL for {filename}")
         release = self.config["release"]
-        logging.debug(f"Release: {release}")
+        logger.debug(f"Release: {release}")
         base_url = self.config["git_repo"].rstrip("/")
         url = f"{base_url}{self.GIT_RELEASES_PATH}/{release}/{filename}"
         return url
@@ -388,7 +393,7 @@ class WorkflowStateManager:
         except Exception as e:
             # clean up the temporary file
             Path(file.name).unlink(missing_ok=True)
-            logging.error(f"Error writing stream to file: {e}")
+            logger.error(f"Error writing stream to file: {e}")
             raise e
 
 
@@ -508,16 +513,16 @@ class WorkflowJob:
 
         for output_spec in self.workflow.data_outputs:  # specs are defined in the workflow.yaml file under Outputs
             output_key = f"{self.workflow.input_prefix}.{output_spec['output']}"
-            logging.info(f"Processing output {output_key}")
+            logger.info(f"Processing output {output_key}")
             # get the full path to the output file from the job_runner
             output_file_path = Path(self.job.outputs[output_key])
-            logging.info(f"Output file path: {output_file_path}")
+            logger.info(f"Output file path: {output_file_path}")
             if output_key not in self.job.outputs:
                 if output_spec.get("optional"):
-                    logging.debug(f"Optional output {output_key} not found in job outputs")
+                    logger.debug(f"Optional output {output_key} not found in job outputs")
                     continue
                 else:
-                    logging.warning(f"Required output {output_key} not found in job outputs")
+                    logger.warning(f"Required output {output_key} not found in job outputs")
                     continue
 
 
@@ -531,7 +536,7 @@ class WorkflowJob:
                 # copy the file to the output directory
                 shutil.copy(output_file_path, new_output_file_path)
             else:
-                logging.warning(f"Output directory not provided, not copying {output_file_path} to output directory")
+                logger.warning(f"Output directory not provided, not copying {output_file_path} to output directory")
 
             # create a DataObject object
             data_object = DataObject(
@@ -562,7 +567,7 @@ class WorkflowJob:
             if attr_val.startswith("{outputs."):
                 match = re.match(pattern, attr_val)
                 if not match:
-                    logging.warning(f"Invalid output reference {attr_val}")
+                    logger.warning(f"Invalid output reference {attr_val}")
                     continue
                 logical_names.add(match.group(1))
                 field_names.add(match.group(2))
@@ -579,7 +584,7 @@ class WorkflowJob:
                     if field_name in data:
                         wf_dict[field_name] = data[field_name]
                     else:
-                        logging.warning(f"Field {field_name} not found in {data_path}")
+                        logger.warning(f"Field {field_name} not found in {data_path}")
 
         wfe = workflow_process_factory(wf_dict)
         return wfe


### PR DESCRIPTION
This PR
- updates watcher and workflow utils to use a consistent logging with log level from NMDC_LOG_LEVEL
- wraps all NmdeRuntimeApi methods with the @retry decorator