### PR TITLE
338 workflow automation data objects are missing file size bytes

### DIFF
--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -527,6 +527,7 @@ class WorkflowJob:
 
 
             md5_sum = _md5(output_file_path)
+            file_size_bytes = output_file_path.stat().st_size
             file_url = f"{self.url_root}/{self.was_informed_by}/{self.workflow_execution_id}/{output_file_path.name}"
 
             # copy the file to the output directory if provided
@@ -542,6 +543,7 @@ class WorkflowJob:
             data_object = DataObject(
                 id=output_spec["id"], name=output_file_path.name, type="nmdc:DataObject", url=file_url,
                 data_object_type=output_spec["data_object_type"], md5_checksum=md5_sum,
+                file_size_bytes=file_size_bytes,
                 description=output_spec["description"].replace('{id}', self.workflow_execution_id),
                 was_generated_by=self.workflow_execution_id, )
 

--- a/tests/test_wfutils.py
+++ b/tests/test_wfutils.py
@@ -320,7 +320,7 @@ def test_workflow_execution_record_from_workflow_job(site_config, fixtures_dir, 
     assert wfe.ended_at_time
 
 
-def test_make_data_objects_substutes_workflow_id(site_config, fixtures_dir, tmp_path):
+def test_make_data_objects_includes_workflow_execution_id_and_file_size(site_config, fixtures_dir, tmp_path):
     job_metadata = json.load(open(fixtures_dir / "mags_job_metadata.json"))
     workflow_state = json.load(open(fixtures_dir / "mags_workflow_state.json"))
     job = WorkflowJob(site_config, workflow_state, job_metadata)
@@ -329,7 +329,7 @@ def test_make_data_objects_substutes_workflow_id(site_config, fixtures_dir, tmp_
     for data_object in data_objects:
         assert isinstance(data_object, DataObject)
         assert job.workflow_execution_id in data_object.description
-
+        assert data_object.file_size_bytes
 
 
 


### PR DESCRIPTION
This PR provides:
- update unit test to replicate missing file size
- update to method that makes data objects to include file size