### PR TITLE
Fix incorrect expiration check in refresh_token function

### DIFF
--- a/nmdc_automation/api/nmdcapi.py
+++ b/nmdc_automation/api/nmdcapi.py
@@ -71,7 +71,7 @@ class NmdcRuntimeApi:
     def refresh_token(func):
         def _get_token(self, *args, **kwargs):
             # If it expires in 60 seconds, refresh
-            if not self.token or self.expires_at < time() - 60:
+            if not self.token or self.expires_at < time() + 60:
                 self.get_token()
             return func(self, *args, **kwargs)
 

--- a/nmdc_automation/api/nmdcapi.py
+++ b/nmdc_automation/api/nmdcapi.py
@@ -71,7 +71,7 @@ class NmdcRuntimeApi:
     def refresh_token(func):
         def _get_token(self, *args, **kwargs):
             # If it expires in 60 seconds, refresh
-            if not self.token or self.expires_at + 60 > time():
+            if not self.token or self.expires_at < time() - 60:
                 self.get_token()
             return func(self, *args, **kwargs)
 


### PR DESCRIPTION
This PR addresses a bug in the nmdcRuntimeApi client.  The `refresh_token` function was incorrectly checking for an expired token - the correct check should be:

if not self.token or self.expires_at < time() - 60
- refresh