### PR TITLE
378 bug data objects missing file size bytes

### DIFF
--- a/nmdc_automation/config/siteconfig.py
+++ b/nmdc_automation/config/siteconfig.py
@@ -99,6 +99,14 @@ class SiteConfig:
         return self.config_data["credentials"]["client_secret"]
 
     @property
+    def username(self):
+        return self.config_data["credentials"].get("username", None)
+
+    @property
+    def password(self):
+        return self.config_data["credentials"].get("password", None)
+
+    @property
     @lru_cache(maxsize=None)
     def allowed_workflows(self):
         """Generate a list of allowed workflows."""

--- a/nmdc_automation/run_process/db_tools.py
+++ b/nmdc_automation/run_process/db_tools.py
@@ -2,6 +2,7 @@
 DB Tools.
 """
 import logging
+import json
 import os
 
 import click
@@ -24,20 +25,16 @@ def update_zero_size_files(config_file, update_db):
     logger.info(f"Updating zero size files from {config_file}")
 
     site_config = SiteConfig(config_file)
-    url_root = site_config.url_root
-    headers = {'accept': 'application/json', }
+    client_id = site_config.client_id
+    client_secret = site_config.client_secret
+
 
     import requests
-
-    headers = {'accept': 'application/json', }
+    headers = {'accept': 'application/json', 'Authorization': f'Bearer {client_id} {client_secret}'}
 
     params = {
         'filter': '{"$or": [{"file_size_bytes": {"$exists": false}},{"file_size_bytes": null},{"file_size_bytes": 0}],"$and": [{"url": {"$exists": true}},{"url": {"$regex": "^https://data.microbiomedata.org/data/"}}]}',
         'max_page_size': '10000', }
-
-    response = requests.get(
-        'https://api-dev.microbiomedata.org/nmdcschema/data_object_set', params=params, headers=headers
-    )
 
     response = requests.get(
         'https://api-dev.microbiomedata.org/nmdcschema/data_object_set', params=params, headers=headers
@@ -49,6 +46,11 @@ def update_zero_size_files(config_file, update_db):
 
     logger.info(f"Found {len(data_objects)} data objects with zero size data files")
 
+
+    update_query = {
+        "update": "data_object_set",
+        "updates": [],
+    }
     for dobj in data_objects:
         # get everything after 'data/' in the url
         file_path = dobj['url'].split('data/')[1]
@@ -59,9 +61,32 @@ def update_zero_size_files(config_file, update_db):
         try:
             file_size = os.path.getsize(file_path)
             logger.info(f"File size: {file_size}")
+
+            # There are zero size files on the file system - log a warning and continue
+            if file_size == 0:
+                logger.warning(f"Zero size file: {file_path}")
+                continue
+
+            update = {
+                "q": {"id": dobj['id']},
+                "u": {"$set": {"file_size_bytes": file_size}},
+            }
+            update_query["updates"].append(update)
         except FileNotFoundError:
-            logger.error(f"File not found: {file_path}")
+            logger.warning(f"File not found: {file_path}")
             continue
+
+    if update_db:
+        response = requests.post(
+            'https://api-dev.microbiomedata.org/queries:run', json=update_query, headers=headers
+        )
+        if response.status_code != 200:
+            logger.error(f"Error in response: {response.status_code}")
+            return
+        logger.info("Successfully updated the database")
+    else:
+        logger.info("Dry run. Database not updated")
+        print(json.dumps(update_query, indent=2))
 
 
 if __name__ == "__main__":

--- a/nmdc_automation/run_process/db_tools.py
+++ b/nmdc_automation/run_process/db_tools.py
@@ -25,12 +25,12 @@ def update_zero_size_files(config_file, update_db):
     logger.info(f"Updating zero size files from {config_file}")
 
     site_config = SiteConfig(config_file)
-    client_id = site_config.client_id
-    client_secret = site_config.client_secret
+    username = site_config.username
+    password = site_config.password
 
 
     import requests
-    headers = {'accept': 'application/json', 'Authorization': f'Bearer {client_id} {client_secret}'}
+    headers = {'accept': 'application/json', 'Authorization': f'Basic {username}:{password}'}
 
     params = {
         'filter': '{"$or": [{"file_size_bytes": {"$exists": false}},{"file_size_bytes": null},{"file_size_bytes": 0}],"$and": [{"url": {"$exists": true}},{"url": {"$regex": "^https://data.microbiomedata.org/data/"}}]}',

--- a/nmdc_automation/run_process/db_tools.py
+++ b/nmdc_automation/run_process/db_tools.py
@@ -1,11 +1,12 @@
 """
 DB Tools.
 """
-import click
 import logging
+import os
 
-from nmdc_automation.api import NmdcRuntimeApi
+import click
 
+from nmdc_automation.config import SiteConfig
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -22,4 +23,46 @@ def cli():
 def update_zero_size_files(config_file, update_db):
     logger.info(f"Updating zero size files from {config_file}")
 
-    runtime = NmdcRuntimeApi(config_file)
+    site_config = SiteConfig(config_file)
+    url_root = site_config.url_root
+    headers = {'accept': 'application/json', }
+
+    import requests
+
+    headers = {'accept': 'application/json', }
+
+    params = {
+        'filter': '{"$or": [{"file_size_bytes": {"$exists": false}},{"file_size_bytes": null},{"file_size_bytes": 0}],"$and": [{"url": {"$exists": true}},{"url": {"$regex": "^https://data.microbiomedata.org/data/"}}]}',
+        'max_page_size': '10000', }
+
+    response = requests.get(
+        'https://api-dev.microbiomedata.org/nmdcschema/data_object_set', params=params, headers=headers
+    )
+
+    response = requests.get(
+        'https://api-dev.microbiomedata.org/nmdcschema/data_object_set', params=params, headers=headers
+    )
+    if response.status_code != 200:
+        logger.error(f"Error in response: {response.status_code}")
+        return
+    data_objects = response.json().get("resources", [])
+
+    logger.info(f"Found {len(data_objects)} data objects with zero size data files")
+
+    for dobj in data_objects:
+        # get everything after 'data/' in the url
+        file_path = dobj['url'].split('data/')[1]
+        file_path = os.path.join(site_config.data_dir, file_path)
+
+        logger.info(f"Updating {dobj['id']} /  File size: {dobj.get('file_size_bytes', None)} / File: {file_path}")
+        # try to get the file size in bytes
+        try:
+            file_size = os.path.getsize(file_path)
+            logger.info(f"File size: {file_size}")
+        except FileNotFoundError:
+            logger.error(f"File not found: {file_path}")
+            continue
+
+
+if __name__ == "__main__":
+    cli()

--- a/nmdc_automation/run_process/db_tools.py
+++ b/nmdc_automation/run_process/db_tools.py
@@ -1,0 +1,25 @@
+"""
+DB Tools.
+"""
+import click
+import logging
+
+from nmdc_automation.api import NmdcRuntimeApi
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+@click.argument("config_file", type=click.Path(exists=True))
+@click.option("--update-db", default=False, type=bool, help="Update the database")
+def update_zero_size_files(config_file, update_db):
+    logger.info(f"Updating zero size files from {config_file}")
+
+    runtime = NmdcRuntimeApi(config_file)

--- a/nmdc_automation/run_process/db_tools.py
+++ b/nmdc_automation/run_process/db_tools.py
@@ -20,7 +20,7 @@ def cli():
 
 @cli.command()
 @click.argument("config_file", type=click.Path(exists=True))
-@click.option("--update-db", default=False, type=bool, help="Update the database")
+@click.option("--update-db", is_flag=True, help="Update the database")
 def update_zero_size_files(config_file, update_db):
     logger.info(f"Updating zero size files from {config_file}")
 

--- a/nmdc_automation/run_process/db_tools.py
+++ b/nmdc_automation/run_process/db_tools.py
@@ -22,7 +22,8 @@ def cli():
 @click.argument("config_file", type=click.Path(exists=True))
 @click.option("--update-db", is_flag=True, help="Update the database")
 def update_zero_size_files(config_file, update_db):
-    logger.info(f"Updating zero size files from {config_file}")
+
+    # logger.info(f"Updating zero size files from {config_file}")
 
     site_config = SiteConfig(config_file)
     username = site_config.username


### PR DESCRIPTION
This PR provides a comman `update-zero-size-files` that addresses #378 

**Steps:**

**Query the `nmdcschema/data_object_set` endpoint**
- file_size_bytes zero or missing
- has a nmdc url

**Construct a data file path from the URL and attempt to get the file size**

**Construct an update for each data object that has a sizeable data file**

** Update Database**
- If `--update-db` flag, apply the update query via the `queries:run` endpoint
- otherwise print out the update query as json