### PR TITLE
402 update import projects to ignore nmdcmetagenomesequencing

### DIFF
--- a/configs/import.yaml
+++ b/configs/import.yaml
@@ -487,7 +487,7 @@ Data Objects:
       nmdc_suffix: _input.corr.fastq.gz
       input_to: []
       output_of: nmdc:MetagenomeAssembly
-      mulitple: false
+      multiple: false
       action: rename
     - data_object_type: GOTTCHA2 Report Full
       description: GOTTCHA2 Full Report for {id}

--- a/nmdc_automation/import_automation/import_mapper.py
+++ b/nmdc_automation/import_automation/import_mapper.py
@@ -280,7 +280,10 @@ class ImportMapper:
         in the DB.
         """
 
-        filter = {'was_informed_by': self.data_generation_id}
+        filter = {
+            'was_informed_by': self.data_generation_id,
+            'type': {"$ne": "nmdc:MetagenomeSequencing"}
+        }
         workflow_execution_recs = self.runtime_api.find_planned_processes(filter)
         for workflow_execution in workflow_execution_recs:
             data_object_ids = workflow_execution['has_output']


### PR DESCRIPTION
This PR updates import_mapper `add_do_mappings_from_workflow_executions` to exclude deprecated workflow executions of type nmdc:MetagenomeSequencing