### PR TITLE
Add data generation ID to array in every case

### DIFF
--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -33,8 +33,8 @@ def get_mongo_db() -> MongoDatabase:
     _client = MongoClient(
         host=os.getenv("MONGO_HOST", "localhost"),
         port=int(os.getenv("MONGO_PORT", "27018")),
-        username=os.getenv("MONGO_USERNAME", "admin"),
-        password=os.getenv("MONGO_PASSWORD", "root"),
+        username=os.getenv("MONGO_USERNAME", None),
+        password=os.getenv("MONGO_PASSWORD", None),
         directConnection=True,
     )[os.getenv("MONGO_DBNAME", "nmdc")]
     return _client

--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -374,10 +374,6 @@ def main(site_conf, wf_file):  # pragma: no cover
         for item in allowlist:
             logger.info(f"Allowing: {item}")
 
-    logger.info(f"Adding ID: nmdc:omprc-11-pf500b03 to Allowlist")
-    allowlist = ["nmdc:omprc-11-pf500b03"]
-
-
     logger.info("Starting Scheduler")
     cycle_count = 0
     while True:

--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -32,9 +32,9 @@ logger = logging.getLogger(__name__)
 def get_mongo_db() -> MongoDatabase:
     _client = MongoClient(
         host=os.getenv("MONGO_HOST", "localhost"),
-        port=int(os.getenv("MONGO_PORT", "27017")),
-        username=os.getenv("MONGO_USERNAME", None),
-        password=os.getenv("MONGO_PASSWORD", None),
+        port=int(os.getenv("MONGO_PORT", "27018")),
+        username=os.getenv("MONGO_USERNAME", "admin"),
+        password=os.getenv("MONGO_PASSWORD", "root"),
         directConnection=True,
     )[os.getenv("MONGO_DBNAME", "nmdc")]
     return _client
@@ -373,6 +373,10 @@ def main(site_conf, wf_file):  # pragma: no cover
         logger.info(f"Read {len(allowlist)} items")
         for item in allowlist:
             logger.info(f"Allowing: {item}")
+
+    logger.info(f"Adding ID: nmdc:omprc-11-pf500b03 to Allowlist")
+    allowlist = ["nmdc:omprc-11-pf500b03"]
+
 
     logger.info("Starting Scheduler")
     cycle_count = 0

--- a/nmdc_automation/workflow_automation/workflow_process.py
+++ b/nmdc_automation/workflow_automation/workflow_process.py
@@ -113,9 +113,11 @@ def get_current_workflow_process_nodes(
     for wf in data_generation_workflows:
         # Sequencing workflows don't have a git repo
         for rec in dg_execution_records:
+            # legacy JGI sequencing records won't have output but we still want to include them
+            # The graph in that case will be rooted at the ReadsQC node
+            data_generation_ids.add(rec["id"])
             if _is_missing_required_input_output(wf, rec, data_objects_by_id):
                 continue
-            data_generation_ids.add(rec["id"])
             wfp_node = WorkflowProcessNode(rec, wf)
             workflow_process_nodes.add(wfp_node)
 


### PR DESCRIPTION
This PR provides a change to the workflow_process.py function `get_current_workflow_process_nodes` and changes the order of operations so that DataGeneration ID is added to the function's internal `data_generation_ids` set in every case, whether the DG has output or not
