### PR TITLE
Update input prefix for metaAssembly

### DIFF
--- a/nmdc_automation/config/workflows/workflows.yaml
+++ b/nmdc_automation/config/workflows/workflows.yaml
@@ -101,7 +101,7 @@ Workflows:
     Predecessors:
     - Reads QC
     - Reads QC Interleave
-    Input_prefix: jgi_metaASM
+    Input_prefix: jgi_metaAssembly
     Inputs:
       input_files: do:Filtered Sequencing Reads
       proj: "{workflow_execution_id}"


### PR DESCRIPTION
This PR updates the Metagenome Assembly `Input_prefix` from jgi_metaASM to jgi_metaAssembly to conform to the specified input parameters for 
https://github.com/microbiomedata/metaAssembly
