### PR TITLE
414 update metagenome assembly version to 1.0.8

### DIFF
--- a/nmdc_automation/config/workflows/workflows.yaml
+++ b/nmdc_automation/config/workflows/workflows.yaml
@@ -95,7 +95,7 @@ Workflows:
     Enabled: True
     Analyte Category: Metagenome
     Git_repo: https://github.com/microbiomedata/metaAssembly
-    Version: v1.0.8
+    Version: v1.0.9
     WDL: jgi_assembly.wdl
     Collection: workflow_execution_set
     Predecessors:

--- a/nmdc_automation/config/workflows/workflows.yaml
+++ b/nmdc_automation/config/workflows/workflows.yaml
@@ -95,7 +95,7 @@ Workflows:
     Enabled: True
     Analyte Category: Metagenome
     Git_repo: https://github.com/microbiomedata/metaAssembly
-    Version: v1.0.7
+    Version: v1.0.8
     WDL: jgi_assembly.wdl
     Collection: workflow_execution_set
     Predecessors:

--- a/nmdc_automation/workflow_automation/watch_nmdc.py
+++ b/nmdc_automation/workflow_automation/watch_nmdc.py
@@ -25,7 +25,7 @@ DEFAULT_STATE_DIR = Path(__file__).parent / "_state"
 DEFAULT_STATE_FILE = DEFAULT_STATE_DIR / "state.json"
 INITIAL_STATE = {"jobs": []}
 
-logging_level = os.getenv("NMDC_LOG_LEVEL", logging.DEBUG)
+logging_level = os.getenv("NMDC_LOG_LEVEL", logging.INFO)
 logging.basicConfig(
     level=logging_level, format="%(asctime)s %(levelname)s: %(message)s"
 )

--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -22,7 +22,7 @@ from nmdc_automation.models.nmdc import DataObject, WorkflowExecution, workflow_
 
 DEFAULT_MAX_RETRIES = 2
 
-logging_level = os.getenv("NMDC_LOG_LEVEL", logging.DEBUG)
+logging_level = os.getenv("NMDC_LOG_LEVEL", logging.INFO)
 logging.basicConfig(
     level=logging_level, format="%(asctime)s %(levelname)s: %(message)s"
 )


### PR DESCRIPTION
This PR provides:
- Update workflows.yaml to metagenome assembly version 1.0.8
- set default logging level to INFO