### PR TITLE
Pass input_files value as an array

### DIFF
--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -129,7 +129,12 @@ class Scheduler:
                         continue
                     raise ValueError(f"Unable to find {do_type} in {do_by_type}")
                 input_data_objects.append(dobj.as_dict())
-                v = dobj["url"]
+
+                if k == "input_files":
+                    v = [dobj["url"]]
+                else:
+                    v = dobj["url"]
+                    
             # TODO: Make this smarter
             elif v == "{was_informed_by}":
                 v = job.informed_by

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -266,4 +266,27 @@ def test_scheduler_find_new_jobs(test_db, mock_api, workflows_config_dir, site_c
     assert job_req["config"]["input_data_objects"]
 
 
+def test_scheduler_create_job_rec_has_input_files_as_array(test_db, mock_api, workflows_config_dir, site_config_file):
+    """
+    Test that the input_data_objects field is an array of strings.
+    """
+    reset_db(test_db)
+    load_fixture(test_db, "data_object_set.json")
+    load_fixture(test_db, "data_generation_set.json")
+    load_fixture(test_db, "read_qc_analysis.json", col="workflow_execution_set")
+
+    jm = Scheduler(
+        test_db, workflow_yaml=workflows_config_dir / "workflows.yaml",
+        site_conf=site_config_file
+        )
+
+    resp = jm.cycle()
+    assemblies = [j for j in resp if j["config"]["activity"]["type"] == "nmdc:MetagenomeAssembly"]
+    assert assemblies
+    assembly = assemblies[0]
+
+    assert isinstance(assembly["config"]["inputs"]["shortRead"], bool)
+    assert assembly["config"]["inputs"]["shortRead"] == False
+    assert isinstance(assembly["config"]["inputs"]["input_files"], list)
+
 


### PR DESCRIPTION
This PR updates the sched.py function `create_job_rec` to pass the value for `input_files` (taken by metaAssembly and ReadsQC) as an array. 