### PR TITLE
Updating import yaml files to fix fastq.gz.md5 import issues

### DIFF
--- a/configs/import-mt.yaml
+++ b/configs/import-mt.yaml
@@ -128,7 +128,7 @@ Data Objects:
     - data_object_type: Metagenome Raw Reads
       description: Metagenome Raw Reads for {id}
       name: Raw sequencer read data
-      import_suffix: .[A-Z]+-[A-Z]+.fastq.gz
+      import_suffix:  \.[ACGT]+-[ACGT]+\.fastq\.gz$
       nmdc_suffix: .fastq.gz
       input_to: [nmdc:ReadQcAnalysis]
       output_of: nmdc:NucleotideSequencing

--- a/configs/import.yaml
+++ b/configs/import.yaml
@@ -159,7 +159,7 @@ Data Objects:
     - data_object_type: Metagenome Raw Reads
       description: Metagenome Raw Reads for {id}
       name: Raw sequencer read data
-      import_suffix: .[A,C,G,T]+-[A,C,G,T]+.fastq.gz
+      import_suffix:  \.[ACGT]+-[ACGT]+\.fastq\.gz$
       nmdc_suffix: .fastq.gz
       input_to: [nmdc:ReadQcAnalysis]
       output_of: nmdc:NucleotideSequencing

--- a/tests/test_import_mapper.py
+++ b/tests/test_import_mapper.py
@@ -31,6 +31,8 @@ def mock_minted_ids():
 
 def test_update_do_mappings_from_import_files(import_mapper_instance):
     import_mapper_instance.update_do_mappings_from_import_files()
+    for fm_all in import_mapper_instance.mappings:
+        print(fm_all, "\n\n")
     assert len(import_mapper_instance.mappings) == 22
 
 


### PR DESCRIPTION
Changed `import_suffix` for `data_object_type: Metagenome Raw Reads` in `import.yaml`  and ` import-mt.yaml`
from --> `import_suffix: .[A,C,G,T]+-[A,C,G,T]+.fastq.gz`
to --> `import_suffix: \.[ACGT]+-[ACGT]+\.fastq\.gz$`
should resolve this issue.

`\. `matches a literal dot (.).

`[ACGT]+ `matches one or more occurrences of the letters A, C, G, or T.

`- `matches a literal hyphen (-).

`[ACGT]+ `matches one or more occurrences of the letters A, C, G, or T again.

`\.fastq\.gz` matches the literal string .fastq.gz.

`$` ensures that the pattern matches only at the end of the string, so it won’t match `.fastq.gz.md5` 