### PR TITLE
Update Dockerfile to python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.11
 
 RUN \
     pip install poetry && \


### PR DESCRIPTION
This PR updates the Python version in the Dockerfile to 3.11 to satisfy version requirements for jaws-client