### PR TITLE
429 implement tool to fix mal-formed urls

### DIFF
--- a/nmdc_automation/run_process/db_tools.py
+++ b/nmdc_automation/run_process/db_tools.py
@@ -119,10 +119,10 @@ def fix_data_object_urls(config_file, update_db):
 
     params = {
         'filter': '{"url": {"$regex": "/ficus/"}}',
-        'max_page_size': '1000', }
+        'max_page_size': '10000', }
 
     response = requests.get(
-        'https://api-dev.microbiomedata.org/nmdcschema/data_object_set', params=params, headers=headers
+        'https://api.microbiomedata.org/nmdcschema/data_object_set', params=params, headers=headers
     )
     if response.status_code != 200:
         logger.error(f"Error in response: {response.status_code}")
@@ -140,7 +140,8 @@ def fix_data_object_urls(config_file, update_db):
         # Raw reads don't get a URL
         if dobj['data_object_type'] == 'Metagenome Raw Reads':
             # delete the url
-            dobj.delete('url')
+            if 'url' in dobj:
+                dobj.pop('url')
             data_object_set.append(dobj)
             continue
 

--- a/nmdc_automation/run_process/db_tools.py
+++ b/nmdc_automation/run_process/db_tools.py
@@ -153,17 +153,30 @@ def fix_data_object_urls(config_file, update_db):
 
     data_objects_update = {"data_object_set": data_object_set}
     data_objects_json = json.dumps(data_objects_update, indent=2)
-    print(data_objects_json)
 
     # check that the json is valid
     logger.info("Validating metadata")
     val_result = runtime_api.validate_metadata(data_objects_update)
     if val_result['result'] == "All Okay!":
         logger.info("Metadata is valid")
+
+        if update_db:
+            logger.info("Updating the database")
+            resp = runtime_api.submit_metadata(data_objects_update)
+            logger.info(resp)
+
+        else:
+            logger.info("Dry run. Database not updated")
+            print(data_objects_json)
+            return
+
     else:
         logger.error("Metadata is not valid")
         logger.error(val_result)
+        print(data_objects_json)
         return
+
+
 
 
 


### PR DESCRIPTION
This PR provides a command fix-data-object-urls that:
- Finds DataObjects with  mal-formed URLS - in this case including the incorrect path with `/ficus/` in the path and:
- - Updates the URL in the DataObject to the correct URL if the data_object_type is not raw sequencing
- -  Deletes the URL if the DataObject is raw sequencing
- validates the updated data_object_set
- if selected, submit the updated data object set to the `metadata:submit` endpoint


Successfully tested in the dev environment - verified that the corrected URLs were resolvable