### PR TITLE
374 implement jawsrunner job status and metadata methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 test:
-	poetry run pytest --cov-report term --cov=nmdc_automation -m "not (integration or jaws)" ./tests
+	poetry run pytest --cov-report term --cov=nmdc_automation -m "not (integration or jaws or jaws_submit)" ./tests
 
 test-jaws:
 	poetry run pytest -m "jaws" ./tests

--- a/configs/site_configuration.toml
+++ b/configs/site_configuration.toml
@@ -27,3 +27,8 @@ workflows_config = "./configs/workflows.yaml"
 [credentials]
 client_id = "xxxxxx"
 client_secret = "xxxxxxxx"
+
+[jaws]
+jaws_config = "path/to/jaws/config"
+jaws_token = "path/to/jaws/token"
+

--- a/nmdc_automation/config/siteconfig.py
+++ b/nmdc_automation/config/siteconfig.py
@@ -107,6 +107,14 @@ class SiteConfig:
         return self.config_data["credentials"].get("password", None)
 
     @property
+    def jaws_config(self):
+        return self.config_data["jaws"]["jaws_config"]
+
+    @property
+    def jaws_token(self):
+        return self.config_data["jaws"]["jaws_token"]
+
+    @property
     @lru_cache(maxsize=None)
     def allowed_workflows(self):
         """Generate a list of allowed workflows."""

--- a/nmdc_automation/run_process/run_workflows.py
+++ b/nmdc_automation/run_process/run_workflows.py
@@ -30,7 +30,7 @@ def watcher(ctx, site_configuration_file):
     ctx.obj = Watcher(site_configuration_file)
 
 
-@watcher.command()
+@cli.command()
 @click.pass_context
 @click.argument("job_ids", nargs=-1)
 def submit(ctx, job_ids):
@@ -52,7 +52,7 @@ def submit(ctx, job_ids):
         watcher.job_checkpoint()
 
 
-@watcher.command()
+@cli.command()
 @click.pass_context
 @click.argument("workflow_execution_ids", nargs=-1)
 def resubmit(ctx, workflow_execution_ids):
@@ -83,7 +83,7 @@ def resubmit(ctx, workflow_execution_ids):
         watcher.job_manager.save_checkpoint()
 
 
-@watcher.command()
+@cli.command()
 @click.pass_context
 def sync(ctx):
     watcher = ctx.obj
@@ -91,14 +91,14 @@ def sync(ctx):
     watcher.update_op_state_all()
 
 
-@watcher.command()
+@cli.command()
 @click.pass_context
 def daemon(ctx):
     watcher = ctx.obj
     watcher.watch()
 
 
-@watcher.command()
+@cli.command()
 @click.pass_context
 @click.argument("opid")
 def reset(ctx, opid):

--- a/nmdc_automation/run_process/run_workflows.py
+++ b/nmdc_automation/run_process/run_workflows.py
@@ -19,15 +19,16 @@ def cli():
     type=click.Path(exists=True),
     required=True,
 )
+@click.option(  "-jaws", "--jaws", is_flag=True, type=bool, default=False)
 @click.pass_context
-def watcher(ctx, site_configuration_file):
+def watcher(ctx, site_configuration_file, jaws):
     logging_level = os.getenv("NMDC_LOG_LEVEL", logging.INFO)
     logging.basicConfig(
         level=logging_level, format="%(asctime)s %(levelname)s: %(message)s"
     )
     logger = logging.getLogger(__name__)
     logger.info(f"Initializing Watcher: config file: {site_configuration_file}")
-    ctx.obj = Watcher(site_configuration_file)
+    ctx.obj = Watcher(site_configuration_file, use_jaws=jaws)
 
 
 @cli.command()

--- a/nmdc_automation/workflow_automation/watch_nmdc.py
+++ b/nmdc_automation/workflow_automation/watch_nmdc.py
@@ -19,7 +19,8 @@ from nmdc_automation.api import NmdcRuntimeApi
 from nmdc_automation.config import SiteConfig
 from nmdc_automation.workflow_automation.wfutils import WorkflowJob
 
-
+from jaws_client import api as jaws_api
+from jaws_client.config import Configuration as jaws_Configuration
 
 DEFAULT_STATE_DIR = Path(__file__).parent / "_state"
 DEFAULT_STATE_FILE = DEFAULT_STATE_DIR / "state.json"
@@ -335,6 +336,12 @@ class Watcher:
         self.should_skip_claim = False
         self.config = SiteConfig(site_configuration_file)
         self.file_handler = FileHandler(self.config, state_file)
+
+        if use_jaws:
+            jaws_config = jaws_Configuration.from_files(self.config.jaws_config, self.config.jaws_token)
+            self.jaws_api = jaws_api.JawsApi(jaws_config)
+
+
         self.runtime_api_handler = RuntimeApiHandler(self.config)
         self.job_manager = JobManager(self.config, self.file_handler)
         self.nmdc_materialized = _get_nmdc_materialized()

--- a/nmdc_automation/workflow_automation/watch_nmdc.py
+++ b/nmdc_automation/workflow_automation/watch_nmdc.py
@@ -199,7 +199,7 @@ class JobManager:
     def get_finished_jobs(self)->Tuple[List[WorkflowJob], List[WorkflowJob]]:
         """
         Get finished jobs
-        Returns a tuple of successful jobs and failed jobs
+        Returns a tuple of successful jobs and failed jobs.
         Jobs are considered finished if they have a last status of "Succeeded" or "Failed"
         or if they have reached the maximum number of failures
 
@@ -210,20 +210,20 @@ class JobManager:
         failed_jobs = []
         for job in self.job_cache:
             if not job.done:
-                if job.workflow.last_status == "Succeeded" and job.opid:
+                if job.workflow.last_status.lower() == "succeeded" and job.opid:
                     successful_jobs.append(job)
                     continue
-                if job.workflow.last_status == "Failed" and job.workflow.failed_count >= self._MAX_FAILS:
+                if job.workflow.last_status.lower() == "failed" and job.workflow.failed_count >= self._MAX_FAILS:
                     failed_jobs.append(job)
                     continue
                 # check status
                 status = job.job.get_job_status()
 
-                if status == "Succeded":
+                if status.lower() == "succeded":
                     job.workflow.last_status = status
                     successful_jobs.append(job)
                     continue
-                elif status == "Failed":
+                elif status.lower() == "failed":
                     job.workflow.last_status = status
                     job.workflow.failed_count += 1
                     failed_jobs.append(job)

--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -219,7 +219,8 @@ class JawsRunner(JobRunnerABC):
 
 
     def get_job_metadata(self) -> Dict[str, Any]:
-        """ Get metadata for a job. In JAYS this is the response from the status call """
+        """ Get metadata for a job. In JAWS this is the response from the status call and the
+        logical names and file paths for the outputs specified in outputs.json """
         metadata = self.jaws_api.status(self.job_id)
         # load output_dir / outputs.json file
         if "outputs" in metadata:

--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -21,7 +21,7 @@ from nmdc_automation.models.nmdc import DataObject, WorkflowExecution, workflow_
 from jaws_client import api as jaws_api
 from jaws_client.config import Configuration as jaws_Configuration
 
-DEFAULT_MAX_RETRIES = 2
+DEFAULT_MAX_RETRIES = 1
 
 logging_level = os.getenv("NMDC_LOG_LEVEL", logging.INFO)
 logging.basicConfig(
@@ -281,7 +281,7 @@ class JawsRunner(JobRunnerABC):
 
     def max_retries(self) -> int:
         """ Get the maximum number of retries - Set this at 1 for now """
-        return 1
+        return DEFAULT_MAX_RETRIES
 
 
 class CromwellRunner(JobRunnerABC):

--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -280,8 +280,8 @@ class JawsRunner(JobRunnerABC):
         self._metadata = metadata
 
     def max_retries(self) -> int:
-        """ Get the maximum number of retries """
-        return DEFAULT_MAX_RETRIES
+        """ Get the maximum number of retries - Set this at 1 for now """
+        return 1
 
 
 class CromwellRunner(JobRunnerABC):

--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -34,11 +34,11 @@ class JobRunnerABC(ABC):
 
     # States that indicate a job is in some active state and does not need to be submitted
     NO_SUBMIT_STATES = [
-        "Submitted",  # job is already submitted but not running
-        "Running",  # job is already running
-        "Succeeded",  # job succeeded
-        "Aborting"  # job is in the process of being aborted
-        "On Hold",  # job is on hold and not running. It can be manually resumed later
+        "submitted",  # job is already submitted but not running
+        "running",  # job is already running
+        "succeeded",  # job succeeded
+        "aborting"  # job is in the process of being aborted
+        "on hold",  # job is on hold and not running. It can be manually resumed later
     ]
 
     def __init__(self, site_config: SiteConfig, workflow: "WorkflowStateManager"):
@@ -89,15 +89,42 @@ class JawsRunner(JobRunnerABC):
     """ Job runner for J.A.W.S"""
 
     DEFAULT_JOB_SITE = 'nmdc'
+    JAWS_NO_SUBMIT_STATES = [
+        "created",          # The Run was accepted and a run_id assigned.
+        "upload queued",    # The Run's input files are waiting to be transferred to the compute-site.
+        "uploading",        # Your Run's input files are being transferred to the compute-site.
+        "upload failed",    # The transfer of your run to the compute-site failed.
+        "upload inactive",  # Globus transfer stalled.
+        "upload complete",  # Your Run's input files have been transferred to the compute-site successfully.
+        "ready",            # The Run has been transferred to the compute-site.
+        "submitted",        # The run has been submitted to Cromwell and tasks should start to queue within moments.
+        "submission failed", # The run was submitted to Cromwell but rejected due to invalid input.
+        "queued",           # At least one task has requested resources but no tasks have started running yet.
+        "running",          # The run is being executed; you can check `tasks` for more detail.
+        "succeeded",        # The run has completed successfully.
+        "complete",         # Supplementary files have been written to the run's output dir.
+        "finished",         # The task-summary has been published to the performance metrics service.
+        "cancelling",       # Your run is in the process of being canceled.
+        "cancelled",        # The run was cancelled by either the user or an admin.
+        "download queued",  # Your Run's output files are waiting to be transferred from the compute-site.
+        "downloading",      # The Run's output files are being transferred from the compute-site.
+        "download failed",  # The Run's output files could not be transferred from the compute-site.
+        "download inactive", # Globus transfer stalled.
+        "download complete", # Your Run's output (succeeded or failed) have been transferred to the team outdir.
+        "download skipped",  # The run was not successful so the results were not downloaded.
+        "done",             # The run is complete.
+    ]
 
     def __init__(self,
                  site_config: SiteConfig, workflow: "WorkflowStateManager", jaws_api: jaws_api.JawsApi,
-                 job_metadata: Dict[str, Any] = None,):
+                 job_metadata: Dict[str, Any] = None, job_site: str = None) -> None:
         super().__init__(site_config, workflow)
         self.jaws_api = jaws_api
         self._metadata = {}
         if job_metadata:
             self._metadata = job_metadata
+        self.job_site = job_site or self.DEFAULT_JOB_SITE
+        self.no_submit_states = self.JAWS_NO_SUBMIT_STATES + self.NO_SUBMIT_STATES
 
 
     def generate_submission_files(self) -> Dict[str, Any]:
@@ -140,7 +167,7 @@ class JawsRunner(JobRunnerABC):
         :return: {'run_id': 'int'}
         """
         status = self.workflow.last_status
-        if status in self.NO_SUBMIT_STATES and not force:
+        if status.lower() in self.no_submit_states and not force:
             logger.info(f"Job {self.job_id} in state {status}, skipping submission")
             return
         cleanup_zip_files = []
@@ -163,13 +190,14 @@ class JawsRunner(JobRunnerABC):
                 logger.error(f"Failed to Validate Job: {validation_resp}")
                 raise Exception(f"Failed to Validate Job: {validation_resp}")
 
+            tag_value = self.workflow.was_informed_by + "/" + self.workflow.workflow_execution_id
             # Submit to J.A.W.S
             response = self.jaws_api.submit(
                 wdl_file=files["wdl_file"],
                 sub=files["sub"],
                 inputs=files["inputs"],
-                tag = self.workflow.workflow_execution_id,
-                site = self.DEFAULT_JOB_SITE
+                tag = tag_value,
+                site = self.job_site
             )
             self.job_id = response['run_id']
             logger.info(f"Submitted job {response['run_id']}")
@@ -191,26 +219,43 @@ class JawsRunner(JobRunnerABC):
 
 
     def get_job_metadata(self) -> Dict[str, Any]:
-        """ Get metadata for a job """
-        return {}
+        """ Get metadata for a job. In JAYS this is the response from the status call """
+        resp = self.jaws_api.status(self.job_id)
+        return resp
 
     def get_job_status(self) -> str:
-        """ Get the status of a job """
-        return "Not implemented"
+        """
+        Get the status of a job. In JAWS this is the response from the status call
+        and the status and results keys.
+        """
+        resp = self.jaws_api.status(self.job_id)
+        # If the status is not 'done' then the job is still running
+        if resp['status'] != 'done':
+            return 'running'
+        # If the status is 'done' then return the result key
+        return resp['result']
+
+
 
     @property
-    def job_id(self) -> Optional[str]:
+    def job_id(self) -> Optional[int]:
         """ Get the job id from the metadata """
         return self.metadata.get("id", None)
 
     @job_id.setter
-    def job_id(self, job_id: str):
+    def job_id(self, job_id: int):
         """ Set the job id in the metadata """
         self.metadata["id"] = job_id
 
+    @property
     def outputs(self) -> Dict[str, str]:
-        """ Get the outputs """
-        return {}
+        """ Get the outputs from the metadata """
+        return self.metadata.get("outputs", {})
+
+    @outputs.setter
+    def outputs(self, outputs: Dict[str, str]):
+        """ Set the outputs in the metadata """
+        self.metadata["outputs"] = outputs
 
     @property
     def metadata(self) -> Dict[str, Any]:
@@ -313,7 +358,7 @@ class CromwellRunner(JobRunnerABC):
         :return: the job id
         """
         status = self.workflow.last_status
-        if status in self.NO_SUBMIT_STATES and not force:
+        if status.lower() in self.NO_SUBMIT_STATES and not force:
             logger.info(f"Job {self.job_id} in state {status}, skipping submission")
             return
         cleanup_files = []

--- a/tests/fixtures/annotation_jaws_status.json
+++ b/tests/fixtures/annotation_jaws_status.json
@@ -1,0 +1,20 @@
+{
+    "compute_site_id": "nmdc",
+    "cpu_hours": 17.1,
+    "cromwell_run_id": "27acc0ae-963f-4b07-956d-8c033abaa852",
+    "id": 102194,
+    "input_site_id": "nmdc",
+    "json_file": "/tmp/tmp2dkuuba8.json",
+    "output_dir": "/pscratch/sd/n/nmdcda/jaws_outputs/nmdcda/102194/27acc0ae-963f-4b07-956d-8c033abaa852",
+    "result": "succeeded",
+    "status": "done",
+    "status_detail": "The run is complete.",
+    "submitted": "2025-03-20 14:28:28",
+    "tag": "nmdc:wfmgan-12-txbzp952.1",
+    "team_id": "nmdc",
+    "updated": "2025-03-21 06:16:30",
+    "user_id": "nmdcda",
+    "wdl_file": "/tmp/tmpm816n_e0.wdl",
+    "workflow_name": "annotation",
+    "workflow_root": "/pscratch/sd/n/nmjaws/nmdc-prod/cromwell-executions/annotation/27acc0ae-963f-4b07-956d-8c033abaa852"
+  }

--- a/tests/fixtures/mags_jaws_status.json
+++ b/tests/fixtures/mags_jaws_status.json
@@ -1,0 +1,20 @@
+{
+    "compute_site_id": "nmdc",
+    "cpu_hours": 0.0,
+    "cromwell_run_id": "bac04338-cc14-4186-9b08-3deb4096e031",
+    "id": 102193,
+    "input_site_id": "nmdc",
+    "json_file": "/tmp/tmp3yh1w1yh.json",
+    "output_dir": "/pscratch/sd/n/nmdcda/jaws_outputs/nmdcda/102193/bac04338-cc14-4186-9b08-3deb4096e031",
+    "result": "succeeded",
+    "status": "done",
+    "status_detail": "The run is complete.",
+    "submitted": "2025-03-20 14:28:15",
+    "tag": "nmdc:wfmag-12-6jp3gm80.1",
+    "team_id": "nmdc",
+    "updated": "2025-03-20 20:22:49",
+    "user_id": "nmdcda",
+    "wdl_file": "/tmp/tmpbaai8sw1.wdl",
+    "workflow_name": "nmdc_mags",
+    "workflow_root": "/pscratch/sd/n/nmjaws/nmdc-prod/cromwell-executions/nmdc_mags/bac04338-cc14-4186-9b08-3deb4096e031"
+  }

--- a/tests/fixtures/meta_assembly_jaws_status.json
+++ b/tests/fixtures/meta_assembly_jaws_status.json
@@ -1,0 +1,20 @@
+{
+    "compute_site_id": "nmdc",
+    "cpu_hours": 3.37,
+    "cromwell_run_id": "1f9e9431-3eeb-47ee-8f92-11b63d4ee371",
+    "id": 102191,
+    "input_site_id": "nmdc",
+    "json_file": "/tmp/tmp_nf5jcux.json",
+    "output_dir": "/pscratch/sd/n/nmdcda/jaws_outputs/nmdcda/102191/1f9e9431-3eeb-47ee-8f92-11b63d4ee371",
+    "result": "succeeded",
+    "status": "done",
+    "status_detail": "The run is complete.",
+    "submitted": "2025-03-20 14:27:54",
+    "tag": "nmdc:wfmgas-12-ypcg9r09.1",
+    "team_id": "nmdc",
+    "updated": "2025-03-20 21:21:03",
+    "user_id": "nmdcda",
+    "wdl_file": "/tmp/tmpcycmtjln.wdl",
+    "workflow_name": "jgi_metaAssembly",
+    "workflow_root": "/pscratch/sd/n/nmjaws/nmdc-prod/cromwell-executions/jgi_metaAssembly/1f9e9431-3eeb-47ee-8f92-11b63d4ee371"
+  }

--- a/tests/fixtures/read_based_analysis_jaws_status.json
+++ b/tests/fixtures/read_based_analysis_jaws_status.json
@@ -1,0 +1,20 @@
+{
+    "compute_site_id": "nmdc",
+    "cpu_hours": 11.1,
+    "cromwell_run_id": "db8a11fe-eab4-489b-9983-3d0de10b7ea7",
+    "id": 102192,
+    "input_site_id": "nmdc",
+    "json_file": "/tmp/tmpp8zg3ns3.json",
+    "output_dir": "/pscratch/sd/n/nmdcda/jaws_outputs/nmdcda/102192/db8a11fe-eab4-489b-9983-3d0de10b7ea7",
+    "result": "succeeded",
+    "status": "done",
+    "status_detail": "The run is complete.",
+    "submitted": "2025-03-20 14:28:04",
+    "tag": "nmdc:wfrbt-12-yw16js60.1",
+    "team_id": "nmdc",
+    "updated": "2025-03-20 21:44:02",
+    "user_id": "nmdcda",
+    "wdl_file": "/tmp/tmp9jvxpzis.wdl",
+    "workflow_name": "ReadbasedAnalysis",
+    "workflow_root": "/pscratch/sd/n/nmjaws/nmdc-prod/cromwell-executions/ReadbasedAnalysis/db8a11fe-eab4-489b-9983-3d0de10b7ea7"
+  }

--- a/tests/fixtures/rqc_jaws_status.json
+++ b/tests/fixtures/rqc_jaws_status.json
@@ -1,0 +1,20 @@
+{
+    "compute_site_id": "nmdc",
+    "cpu_hours": 0.0,
+    "cromwell_run_id": "3ff367c0-2d3b-40d4-b704-c9b75c77dcdb",
+    "id": 102190,
+    "input_site_id": "nmdc",
+    "json_file": "/tmp/tmpq122g4yj.json",
+    "output_dir": "/pscratch/sd/n/nmdcda/jaws_outputs/nmdcda/102190/3ff367c0-2d3b-40d4-b704-c9b75c77dcdb",
+    "result": "succeeded",
+    "status": "done",
+    "status_detail": "The run is complete.",
+    "submitted": "2025-03-20 14:27:31",
+    "tag": "nmdc:wfrqc-12-s66ntc59.1",
+    "team_id": "nmdc",
+    "updated": "2025-03-20 14:29:39",
+    "user_id": "nmdcda",
+    "wdl_file": "/tmp/tmptc0wes74.wdl",
+    "workflow_name": "nmdc_rqcfilter",
+    "workflow_root": "/pscratch/sd/n/nmjaws/nmdc-prod/cromwell-executions/nmdc_rqcfilter/3ff367c0-2d3b-40d4-b704-c9b75c77dcdb"
+  }

--- a/tests/site_configuration_test.toml
+++ b/tests/site_configuration_test.toml
@@ -27,3 +27,7 @@ workflows_config = "workflows.yaml"
 [credentials]
 client_id = "sys0wm66"
 client_secret = "O8Q!64t,^xy:"
+
+[jaws]
+jaws_config = "jaws-test.conf"
+jaws_token = "jaws-test-token.conf"

--- a/tests/test_watch_nmdc.py
+++ b/tests/test_watch_nmdc.py
@@ -283,7 +283,7 @@ def test_job_manager_get_finished_jobs(site_config, initial_state_file_1_failure
     failed_job_state = json.load(open(fixtures_dir / "failed_job_state_2.json"))
     assert failed_job_state
     failed_job = WorkflowJob(site_config, failed_job_state)
-    assert failed_job.job_status == "Failed"
+    assert failed_job.job_status.lower() == "failed"
     jm.job_cache.append(failed_job)
     # sanity check
     assert len(jm.job_cache) == 3

--- a/tests/test_wfutils.py
+++ b/tests/test_wfutils.py
@@ -95,9 +95,32 @@ def test_jaws_job_runner(site_config, fixtures_dir, jaws_config_file_test, jaws_
     assert job_runner
 
 
+@pytest.fixture(scope="session")
+def mock_jaws_api():
+    with mock.patch("jaws_client.api.JawsApi") as mock_jaws_api:
+        yield mock_jaws_api
+
+
 def test_workflow_job_as_workflow_execution_dict(site_config, fixtures_dir):
     workflow_state = json.load(open(fixtures_dir / "mags_workflow_state.json"))
     job_metadata = json.load(open(fixtures_dir / "mags_job_metadata.json"))
+
+    wfj = WorkflowJob(site_config, workflow_state, job_metadata)
+
+    wfe_dict = wfj.as_workflow_execution_dict
+    assert wfe_dict
+
+
+@pytest.mark.parametrize("fixture_pair", [
+    ("mags_workflow_state.json", "mags_jaws_status.json"),
+    ("annotation_workflow_state.json", "annotation_jaws_status.json"),
+    ("meta_assembly_workflow_state.json", "meta_assembly_jaws_status.json"),
+    ("read_based_analysis_workflow_state.json", "read_based_analysis_jaws_status.json"),
+    ("rqc_workflow_state.json", "rqc_jaws_status.json"),
+])
+def test_jaws_workflow_job_as_workflow_execution_dict(fixture_pair, site_config, fixtures_dir, mock_jaws_api):
+    workflow_state = json.load(open(fixtures_dir / fixture_pair[0]))
+    job_metadata = json.load(open(fixtures_dir / fixture_pair[1]))
 
     wfj = WorkflowJob(site_config, workflow_state, job_metadata)
 


### PR DESCRIPTION
This PR provides updates to the NMDC workflow automation framework:

- Adds methods to the `JawsRunner` class for `get_job_status`, `get_job_metadata` 
- Implements properties for `JawsRunner`
- Updates `Watcher` to construct jaws api and pass to JobManager and NmdcApiManager
- Include jaws_api as a construction argument to the `WorkflowJob` class
- Update `WorkflowJob` to use 'JawsRunner' if passed the jaws_api
- Update tests and fixtuires