### PR TITLE
Remove logic to add resources key value pair to inputs for jobrunner

### DIFF
--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -308,12 +308,6 @@ class CromwellRunner(JobRunnerABC):
         self._max_retries = max_retries
         self.dry_run = dry_run
 
-    def _generate_workflow_inputs(self) -> Dict[str, str]:
-        """ Generate inputs for the job runner from the workflow state """
-        inputs = self.workflow.generate_workflow_inputs()
-        # add the resource to the inputs
-        inputs["resource"] = self.config.resource
-        return inputs
 
     def _generate_workflow_labels(self) -> Dict[str, str]:
         """ Generate labels for the job runner from the workflow state """
@@ -333,7 +327,7 @@ class CromwellRunner(JobRunnerABC):
             # Get file paths
             wdl_file = self.workflow.fetch_release_file(self.workflow.config["wdl"], suffix=".wdl")
             bundle_file = self.workflow.fetch_release_file("bundle.zip", suffix=".zip")
-            workflow_inputs_path = _json_tmp(self._generate_workflow_inputs())
+            workflow_inputs_path = _json_tmp(self.workflow.generate_workflow_inputs())
             workflow_labels_path = _json_tmp(self._generate_workflow_labels())
 
             # Open files

--- a/tests/test_wfutils.py
+++ b/tests/test_wfutils.py
@@ -213,7 +213,7 @@ def test_cromwell_runner_setup_inputs_and_labels(site_config, fixtures_dir):
     job_state = json.load(open(fixtures_dir / "mags_workflow_state.json"))
     workflow = WorkflowStateManager(job_state)
     runner = CromwellRunner(site_config, workflow)
-    inputs = runner._generate_workflow_inputs()
+    inputs = workflow.generate_workflow_inputs()
     assert inputs
     # we expect the inputs to be a key-value dict with URLs as values
     for key, value in inputs.items():


### PR DESCRIPTION
This PR addressed the Bug #447 
where a `resource` key value pair was being inappropriately added to workflow inputs