### PR TITLE
Correct the function call find_jobs_by_opid

### DIFF
--- a/nmdc_automation/run_process/run_workflows.py
+++ b/nmdc_automation/run_process/run_workflows.py
@@ -49,7 +49,7 @@ def submit(ctx, job_ids):
             sys.exit(1)
         else:
             opid = claims[0]["op_id"]
-            job = watcher.find_job_by_opid(opid)
+            job = watcher.job_manager.find_job_by_opid(opid)
             if job:
                 print(f"{job_id} use resubmit")
                 continue
@@ -94,7 +94,7 @@ def resubmit(ctx, operation_ids, all_failures, submit):
 
     if operation_ids:
         for opid in operation_ids:
-            job = watcher.find_job_by_opid(opid)
+            job = watcher.job_manager.find_job_by_opid(opid)
             if job:
                 msg = f"Job for {job.was_informed_by} / {job.workflow_execution_id} Status: {job.job_status}"
                 if submit:


### PR DESCRIPTION
Fixes incorrect function call: watcher.get_jobs_by_opid. This function is located in the JobManager, so the call should be: watcher.job_mamager.get_job_by_opid