### PR TITLE
Add get_failed_jobs to JobManager

### DIFF
--- a/nmdc_automation/workflow_automation/watch_nmdc.py
+++ b/nmdc_automation/workflow_automation/watch_nmdc.py
@@ -165,7 +165,9 @@ class JobManager:
                 # already in cache
                 continue
             wf_job = WorkflowJob(self.config, workflow_state=job, jaws_api=self.jaws_api)
-            logger.info(f"Job from State: {wf_job.was_informed_by} / {wf_job.workflow_execution_id}, Last Status: {wf_job.workflow.last_status} /{wf_job.opid} / {wf_job.workflow.nmdc_jobid}")
+            logger.info(f"Job from State: {wf_job.opid} {wf_job.was_informed_by} / {wf_job.workflow_execution_id}, "
+                        f"Last Status:"
+                        f" {wf_job.workflow.last_status} /{wf_job.opid} / {wf_job.workflow.nmdc_jobid}")
             job_cache_ids.append(wf_job.opid)
             wf_job_list.append(wf_job)
 
@@ -310,6 +312,12 @@ class JobManager:
             logger.info(f"Job Report: {rpt}")
 
         return job_reports
+
+    def get_failed_jobs(self) -> List[WorkflowJob]:
+        """ Get failed jobs """
+        failed_jobs = [job for job in self.job_cache if
+                       job.workflow.last_status and job.workflow.last_status.lower() == "failed"]
+        return failed_jobs
 
 
 

--- a/nmdc_automation/workflow_automation/watch_nmdc.py
+++ b/nmdc_automation/workflow_automation/watch_nmdc.py
@@ -316,7 +316,7 @@ class JobManager:
     def get_failed_jobs(self) -> List[WorkflowJob]:
         """ Get failed jobs """
         failed_jobs = [job for job in self.job_cache if
-                       job.workflow.last_status and job.workflow.last_status.lower() == "failed"]
+                       getattr(job.workflow, "last_status", "").lower() == "failed"]
         return failed_jobs
 
 


### PR DESCRIPTION
Adds a function get_failed_jobs to the job manager. In contrast to get_finished_jobs this function does not attempt to check / update status of unfinished jobs and relies soley on the information in the job cache