### PR TITLE
481 add retries to watcher for jaws functions

### DIFF
--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -10,6 +10,7 @@ import tempfile
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
+from tenacity import retry, wait_exponential, stop_after_attempt
 from typing import Any, Dict, List, Optional, Union
 import pytz
 import requests
@@ -195,6 +196,7 @@ class JawsRunner(JobRunnerABC):
             _cleanup_files(cleanup_zip_files)
 
 
+    @retry(wait=wait_exponential(multiplier=1, min=4, max=10), stop=stop_after_attempt(3))
     def get_job_metadata(self) -> Dict[str, Any]:
         """ Get metadata for a job. In JAWS this is the response from the status call and the
         logical names and file paths for the outputs specified in outputs.json """

--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -217,6 +217,7 @@ class JawsRunner(JobRunnerABC):
         self.metadata = metadata
         return metadata
 
+    @retry(wait=wait_exponential(multiplier=1, min=4, max=10), stop=stop_after_attempt(3))
     def get_job_status(self) -> str:
         """
         Get the status of a job. In JAWS this is the response from the status call

--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -130,6 +130,7 @@ class JawsRunner(JobRunnerABC):
         self.no_submit_states = self.JAWS_NO_SUBMIT_STATES + self.NO_SUBMIT_STATES
 
 
+    @retry(wait=wait_exponential(multiplier=1, min=4, max=10), stop=stop_after_attempt(1))
     def submit_job(self, force: bool = False) -> Optional[int]:
         """
         Submit a job to J.A.W.S. Update the workflow state with the job id and status.

--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -130,7 +130,7 @@ class JawsRunner(JobRunnerABC):
         self.no_submit_states = self.JAWS_NO_SUBMIT_STATES + self.NO_SUBMIT_STATES
 
 
-    @retry(wait=wait_exponential(multiplier=1, min=4, max=10), stop=stop_after_attempt(1))
+    @retry(wait=wait_exponential(multiplier=1, min=4, max=10), stop=stop_after_attempt(2))
     def submit_job(self, force: bool = False) -> Optional[int]:
         """
         Submit a job to J.A.W.S. Update the workflow state with the job id and status.

--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -865,4 +865,4 @@ def _cleanup_dirs(dir_paths: list[str | Path]):
         try:
             shutil.rmtree(path)
         except Exception as e:
-            print(f"Error removing directory {path}: {e}")
+            logger.error(f"Error removing directory {path}: {e}")


### PR DESCRIPTION
This PR Provides:
Updates functions in the `JawsRunner` class to use the `tenacity` retry functionality.  Updated functions
- submit_job
- get_job_metadata
- get_job_status