### PR TITLE
406 bug scheduler not finding workflow process nodes

### DIFF
--- a/nmdc_automation/config/workflows/workflows-mt.yaml
+++ b/nmdc_automation/config/workflows/workflows-mt.yaml
@@ -4,15 +4,15 @@ Workflows:
     Enabled: True
     Analyte Category: Metatranscriptome
     Filter Output Objects:
-    - Metagenome Raw Read 1
-    - Metagenome Raw Read 2
+    - Metatranscriptome Raw Read 1
+    - Metatranscriptome Raw Read 2
 
   - Name: Sequencing Interleaved
     Collection: data_generation_set
     Enabled: True
     Analyte Category: Metatranscriptome
     Filter Output Objects:
-    - Metagenome Raw Reads
+    - Metatranscriptome Raw Reads
 
   - Name: Metatranscriptome Reads QC
     Type: nmdc:ReadQcAnalysis
@@ -23,13 +23,13 @@ Workflows:
     WDL: rqcfilter.wdl
     Collection: workflow_execution_set
     Filter Input Objects:
-    - Metagenome Raw Reads
+    - Metatranscriptome Raw Reads
     Predecessors:
     - Sequencing
     - Sequencing Interleaved
     Input_prefix: nmdc_rqcfilter
     Inputs:
-      input_files: do:Metagenome Raw Reads
+      input_files: do:Metatranscriptome Raw Reads
       proj: "{workflow_execution_id}"
     Workflow Execution:
       name: "Read QC for {id}"
@@ -67,11 +67,11 @@ Workflows:
     Input_prefix: nmdc_rqcfilter
     Inputs:
       proj: "{workflow_execution_id}"
-      input_fastq1: do:Metagenome Raw Read 1
-      input_fastq2: do:Metagenome Raw Read 2
+      input_fastq1: do:Metatranscriptome Raw Read 1
+      input_fastq2: do:Metatranscriptome Raw Read 2
     Filter Input Objects:
-    - Metagenome Raw Read 1
-    - Metagenome Raw Read 2
+    - Metatranscriptome Raw Read 1
+    - Metatranscriptome Raw Read 2
     Predecessors:
     - Sequencing Noninterleaved
     Workflow Execution:

--- a/nmdc_automation/config/workflows/workflows-mt.yaml
+++ b/nmdc_automation/config/workflows/workflows-mt.yaml
@@ -1,5 +1,5 @@
 Workflows:
-  - Name: Sequencing Noninterleaved
+  - Name: Metatranscriptome Sequencing Noninterleaved
     Collection: data_generation_set
     Enabled: True
     Analyte Category: Metatranscriptome
@@ -7,7 +7,7 @@ Workflows:
     - Metatranscriptome Raw Read 1
     - Metatranscriptome Raw Read 2
 
-  - Name: Sequencing Interleaved
+  - Name: Metatranscriptome Sequencing Interleaved
     Collection: data_generation_set
     Enabled: True
     Analyte Category: Metatranscriptome
@@ -19,7 +19,7 @@ Workflows:
     Enabled: True
     Analyte Category: Metatranscriptome
     Git_repo: https://github.com/microbiomedata/metaT_ReadsQC
-    Version: v0.0.7
+    Version: v0.0.10
     WDL: rqcfilter.wdl
     Collection: workflow_execution_set
     Filter Input Objects:
@@ -27,7 +27,7 @@ Workflows:
     Predecessors:
     - Sequencing
     - Sequencing Interleaved
-    Input_prefix: nmdc_rqcfilter
+    Input_prefix: metaTReadsQC
     Inputs:
       input_files: do:Metatranscriptome Raw Reads
       proj: "{workflow_execution_id}"
@@ -61,10 +61,10 @@ Workflows:
     Enabled: True
     Analyte Category: Metatranscriptome
     Git_repo: https://github.com/microbiomedata/metaT_ReadsQC
-    Version: v0.0.7
+    Version: v0.0.10
     Collection: workflow_execution_set
     WDL: interleave_rqcfilter.wdl
-    Input_prefix: nmdc_rqcfilter
+    Input_prefix: metaTReadsQC
     Inputs:
       proj: "{workflow_execution_id}"
       input_fastq1: do:Metatranscriptome Raw Read 1
@@ -94,26 +94,26 @@ Workflows:
         name: File containing read filtering information
         data_object_type: Read Filtering Info File
         description: "Read filtering info for {id}"
-      - output: rrna_fastq_final #placeholder until https://github.com/microbiomedata/metaT_ReadsQC/issues/5 is resolved
-        name: Fastq file containing filtered ribosomal sequences             
+      - output: rrna_fastq_final
+        name: Fastq file containing filtered ribosomal sequences
         data_object_type: rRNA Filtered Sequencing Reads
         description: "rRNA fastq for {id}"
- 
+
   - Name: Metatranscriptome Assembly
     Type: nmdc:MetatranscriptomeAssembly
     Enabled: True
     Analyte Category: Metatranscriptome
     Git_repo: https://github.com/microbiomedata/metaT_Assembly
-    Version: v0.0.2
+    Version: v0.0.4
     WDL: metaT_assembly.wdl
     Collection: workflow_execution_set
     Predecessors:
     - Metatranscriptome Reads QC
     - Metatranscriptome Reads QC Interleave
-    Input_prefix: jgi_metaASM
+    Input_prefix: metatranscriptome_assy
     Inputs:
       input_files: do:Filtered Sequencing Reads
-      proj: "{workflow_execution_id}"
+      proj_id: "{workflow_execution_id}"
     Workflow Execution:
       name: "Metatranscriptome Assembly for {id}"
       type: nmdc:MetatranscriptomeAssembly
@@ -150,7 +150,7 @@ Workflows:
       - output: final_bamidx
         name: Indexed bam file
         data_object_type: BAI File
-        description: "Alignment index file for {id}" 
+        description: "Alignment index file for {id}"
 
   - Name: Metatranscriptome Annotation
     Type: nmdc:MetatranscriptomeAnnotation
@@ -280,24 +280,24 @@ Workflows:
     Enabled: False
     Analyte Category: Metatranscriptome
     Git_repo: https://github.com/microbiomedata/metaT_ReadCounts
-    Version: v0.0.5
+    Version: v0.0.7
     WDL: readcount.wdl
     Collection: workflow_execution_set
     Predecessors:
     - Metatranscriptome Annotation
-    Input_prefix: nmdc_expression
+    Input_prefix: readcount
     Inputs:
       gff_file: do:Functional Annotation GFF
       map: do:Contig Mapping File
       bam: do:Assembly Coverage BAM
       rna_type: "aRNA"
-      proj: "{workflow_execution_id}"
+      proj_id: "{workflow_execution_id}"
     Workflow Execution:
       name: "Metatranscriptome Expression Analysis for {id}"
       type: nmdc:MetatranscriptomeExpressionAnalysis
     Outputs:
     - output: count_table
-      data_object_type: Metatranscriptome Expression 
+      data_object_type: Metatranscriptome Expression
       description: Expression counts for {id}
       name: Metatranscriptome expression table
     - output: info_file
@@ -310,17 +310,17 @@ Workflows:
     Enabled: True
     Analyte Category: Metatranscriptome
     Git_repo: https://github.com/microbiomedata/metaT_ReadCounts
-    Version: v0.0.5
+    Version: v0.0.7
     WDL: readcount.wdl
     Collection: workflow_execution_set
     Predecessors:
     - Metatranscriptome Annotation
-    Input_prefix: nmdc_expression
+    Input_prefix: readcount
     Inputs:
       gff_file: do:Functional Annotation GFF
       map: do:Contig Mapping File
       bam: do:Assembly Coverage BAM
-      proj: "{workflow_execution_id}"
+      proj_id: "{workflow_execution_id}"
     Workflow Execution:
       name: "Metatranscriptome Expression Analysis for {id}"
       type: nmdc:MetatranscriptomeExpressionAnalysis
@@ -339,18 +339,18 @@ Workflows:
     Enabled: False
     Analyte Category: Metatranscriptome
     Git_repo: https://github.com/microbiomedata/metaT_ReadCounts
-    Version: v0.0.5
+    Version: v0.0.7
     WDL: readcount.wdl
     Collection: workflow_execution_set
     Predecessors:
     - Metatranscriptome Annotation
-    Input_prefix: nmdc_expression
+    Input_prefix: readcount
     Inputs:
       gff_file: do:Functional Annotation GFF
       map: do:Contig Mapping File
       bam: do:Assembly Coverage BAM
       rna_type: "non_stranded_RNA"
-      proj: "{workflow_execution_id}"
+      proj_id: "{workflow_execution_id}"
     Workflow Execution:
       name: "Metatranscriptome Expression Analysis for {id}"
       type: nmdc:MetatranscriptomeExpressionAnalysis
@@ -363,3 +363,4 @@ Workflows:
       data_object_type: Metatranscriptome Expression Info File
       description: Expression info for {id}
       name: Metatranscriptome Expression Info File
+    

--- a/nmdc_automation/config/workflows/workflows-mt.yaml
+++ b/nmdc_automation/config/workflows/workflows-mt.yaml
@@ -25,8 +25,7 @@ Workflows:
     Filter Input Objects:
     - Metatranscriptome Raw Reads
     Predecessors:
-    - Sequencing
-    - Sequencing Interleaved
+    - Metatranscriptome Sequencing Interleaved
     Input_prefix: metaTReadsQC
     Inputs:
       input_files: do:Metatranscriptome Raw Reads
@@ -73,7 +72,7 @@ Workflows:
     - Metatranscriptome Raw Read 1
     - Metatranscriptome Raw Read 2
     Predecessors:
-    - Sequencing Noninterleaved
+    - Metatranscriptome Sequencing Noninterleaved
     Workflow Execution:
       name: "Read QC for {id}"
       input_read_bases: "{outputs.stats.input_read_bases}"

--- a/tests/fixtures/nmdc_db/data_object_set.json
+++ b/tests/fixtures/nmdc_db/data_object_set.json
@@ -453,7 +453,7 @@
     "description": "Sequencing results for metaT_R1",
     "file_size_bytes": 123456,
     "md5_checksum": "4c7f1be37f805836162b49da4ed9c7e5",
-    "data_object_type": "Metagenome Raw Read 1",
+    "data_object_type": "Metatranscriptome Raw Read 1",
     "type": "nmdc:DataObject",
     "url": "https://portal.nersc.gov"
   },
@@ -463,7 +463,7 @@
     "description": "Sequencing results for metaT_R2",
     "file_size_bytes": 123456,
     "md5_checksum": "4c7f1be37f805836162b49da4ed9c7e5",
-    "data_object_type": "Metagenome Raw Read 2",
+    "data_object_type": "Metatranscriptome Raw Read 2",
     "type": "nmdc:DataObject",
     "url": "https://portal.nersc.gov"
   },

--- a/tests/fixtures/nmdc_db/read_qc_analysis.json
+++ b/tests/fixtures/nmdc_db/read_qc_analysis.json
@@ -38,6 +38,6 @@
       "nmdc:dobj-11-filteredreads1",
       "nmdc:dobj-11-rrnafastq"
     ],
-    "version": "v0.0.7"
+    "version": "v0.0.10"
   }
 ]

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -9,7 +9,7 @@ from tests.fixtures.db_utils import init_test, load_fixture, read_json, reset_db
 
 
 @mark.parametrize("workflow_file", [
-    "workflows.yaml",
+    # "workflows.yaml",
     "workflows-mt.yaml"
 ])
 def test_scheduler_cycle(test_db, mock_api, workflow_file, workflows_config_dir, site_config_file):

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -9,7 +9,7 @@ from tests.fixtures.db_utils import init_test, load_fixture, read_json, reset_db
 
 
 @mark.parametrize("workflow_file", [
-    # "workflows.yaml",
+    "workflows.yaml",
     "workflows-mt.yaml"
 ])
 def test_scheduler_cycle(test_db, mock_api, workflow_file, workflows_config_dir, site_config_file):

--- a/tests/test_workflow_process.py
+++ b/tests/test_workflow_process.py
@@ -231,7 +231,11 @@ def test_get_required_data_objects_by_id(test_db, workflows_config_dir, workflow
     Test get_required_data_objects_by_id
     """
     # non-comprehensive list of expected data object types
-    exp_do_types = ["Metagenome Raw Read 1", "Metagenome Raw Read 2", "Filtered Sequencing Reads"]
+    if workflow_file == "workflows.yaml":
+        exp_do_types = ["Metagenome Raw Read 1", "Metagenome Raw Read 2", "Filtered Sequencing Reads"]
+    else:
+        exp_do_types = ["Metatranscriptome Raw Read 1", "Metatranscriptome Raw Read 2", "Filtered Sequencing Reads"]
+
     # TODO: add workflow specific data objects
     reset_db(test_db)
     load_fixture(test_db, "data_object_set.json")

--- a/tests/test_workflow_process.py
+++ b/tests/test_workflow_process.py
@@ -13,7 +13,10 @@ from tests.fixtures.db_utils import  load_fixture, reset_db
 
 
 @mark.parametrize(
-    "workflow_file", ["workflows.yaml", "workflows-mt.yaml"]
+    "workflow_file", [
+        "workflows.yaml",
+        "workflows-mt.yaml"
+    ]
 )
 def test_load_workflow_process_nodes(test_db, workflow_file, workflows_config_dir):
     """


### PR DESCRIPTION
This PR provides changes to address:
#475 
Reopened based on results from attempting to schedule a MT sample on dev:
```
2025-04-29 17:37:42,193 INFO: Initializing Scheduler
2025-04-29 17:37:42,198 INFO: Reading Allowlist
2025-04-29 17:37:42,198 INFO: Read 1 items
2025-04-29 17:37:42,198 INFO: Allowing: nmdc:dgns-11-t9appd58
2025-04-29 17:37:42,198 INFO: Starting Scheduler
2025-04-29 17:37:42,751 INFO: No workflow process nodes found for {'nmdc:dgns-11-t9appd58'}
``` 

The expected result would be for the Scheduler to find a workflow process node for Metatranscriptome Reads QC Interleave

This error did not initially reproduce in testing, due to `data_object_type` values for MetaT data objects in the test fixtures was not set to the current/correct value

Summary of Changes:
- Merge workflows-mt.yaml changes from #470 
- Update workflows-mt.yaml predecessor values
- Update test fixtures to use current / correct data object types
- Update tests
