### PR TITLE
Change gff_file to gff for readcount inputs

### DIFF
--- a/nmdc_automation/config/workflows/workflows-mt.yaml
+++ b/nmdc_automation/config/workflows/workflows-mt.yaml
@@ -286,7 +286,7 @@ Workflows:
     - Metatranscriptome Annotation
     Input_prefix: readcount
     Inputs:
-      gff_file: do:Functional Annotation GFF
+      gff: do:Functional Annotation GFF
       map: do:Contig Mapping File
       bam: do:Assembly Coverage BAM
       rna_type: "aRNA"
@@ -316,7 +316,7 @@ Workflows:
     - Metatranscriptome Annotation
     Input_prefix: readcount
     Inputs:
-      gff_file: do:Functional Annotation GFF
+      gff: do:Functional Annotation GFF
       map: do:Contig Mapping File
       bam: do:Assembly Coverage BAM
       proj_id: "{workflow_execution_id}"
@@ -345,7 +345,7 @@ Workflows:
     - Metatranscriptome Annotation
     Input_prefix: readcount
     Inputs:
-      gff_file: do:Functional Annotation GFF
+      gff: do:Functional Annotation GFF
       map: do:Contig Mapping File
       bam: do:Assembly Coverage BAM
       rna_type: "non_stranded_RNA"


### PR DESCRIPTION
In `workflows-mt.yaml`, the input for readcounts was `gff_file` instead of `gff`. Corrected the three instances so that the input will be recognized. 

from `readcount.wdl`
https://github.com/microbiomedata/metaT_ReadCounts/blob/b895763825061bc28bcb7fa4721111d86ed98c82/readcount.wdl#L6C1-L16C4

from `workflows-mt.yaml`
https://github.com/microbiomedata/nmdc_automation/blob/1cbd46a160daf78dd4985ce76985f9211c435624/nmdc_automation/config/workflows/workflows-mt.yaml#L288-L293

pulling onto dev to continue end-to-end metaT testing. 