### PR TITLE
484 jaws runs are not capturing at ended at time

### DIFF
--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -272,6 +272,16 @@ class JawsRunner(JobRunnerABC):
         """ Get the maximum number of retries - Set this at 1 for now """
         return DEFAULT_MAX_RETRIES
 
+    @property
+    def started_at_time(self) -> Optional[str]:
+        """ Get the start time of the job """
+        return self.metadata.get("submitted", None)
+
+    @property
+    def ended_at_time(self) -> Optional[str]:
+        """ Get the end time of the job """
+        return self.metadata.get("updated", None)
+
 
 class CromwellRunner(JobRunnerABC):
     """Job runner for Cromwell"""
@@ -394,6 +404,16 @@ class CromwellRunner(JobRunnerABC):
     @property
     def max_retries(self) -> int:
         return self._max_retries
+
+    @property
+    def started_at_time(self) -> Optional[str]:
+        """ Get the start time of the job """
+        return self.metadata.get("start", None)
+
+    @property
+    def ended_at_time(self) -> Optional[str]:
+        """ Get the end time of the job """
+        return self.metadata.get("end", None)
 
 
 class WorkflowStateManager:
@@ -713,11 +733,16 @@ class WorkflowJob:
         """
         Create a dictionary representation of the basic workflow execution attributes for a WorkflowJob.
         """
-        base_dict = {"id": self.workflow_execution_id, "type": self.workflow.workflow_execution_type,
-            "name": self.workflow.workflow_execution_name, "git_url": self.workflow.config["git_repo"],
-            "execution_resource": self.execution_resource, "was_informed_by": self.was_informed_by,
+        base_dict = {
+            "id": self.workflow_execution_id,
+            "type": self.workflow.workflow_execution_type,
+            "name": self.workflow.workflow_execution_name,
+            "git_url": self.workflow.config["git_repo"],
+            "execution_resource": self.execution_resource,
+            "was_informed_by": self.was_informed_by,
             "has_input": [dobj["id"] for dobj in self.workflow.config["input_data_objects"]],
-            "started_at_time": self.workflow.state.get("start"), "ended_at_time": self.workflow.state.get("end"),
+            "started_at_time": self.job.started_at_time,
+            "ended_at_time": self.job.ended_at_time,
             "version": self.workflow.config["release"], }
         return base_dict
 

--- a/tests/test_wfutils.py
+++ b/tests/test_wfutils.py
@@ -122,9 +122,10 @@ def test_jaws_workflow_job_as_workflow_execution_dict(fixture_pair, site_config,
     workflow_state = json.load(open(fixtures_dir / fixture_pair[0]))
     job_metadata = json.load(open(fixtures_dir / fixture_pair[1]))
 
-    wfj = WorkflowJob(site_config, workflow_state, job_metadata)
+    wfj = WorkflowJob(site_config, workflow_state, job_metadata, jaws_api=mock_jaws_api)
 
     wfe_dict = wfj.as_workflow_execution_dict
+    assert wfe_dict['ended_at_time']
     assert wfe_dict
 
 


### PR DESCRIPTION
This PR provides a fix for issue #484 

Summary of changes:
This pull request introduces enhancements to the `WorkflowJob` class and its related functionality in `wfutils.py`, focusing on improving metadata handling for job start and end times. Additionally, it updates the corresponding test to ensure these changes are properly validated.

### Enhancements to metadata handling:

* Added `started_at_time` and `ended_at_time` properties to the `WorkflowJob` class to retrieve job start and end times from metadata. (`nmdc_automation/workflow_automation/wfutils.py`) [[1]](diffhunk://#diff-821850501f13006ad39cfb3322383c570b9a09be6bef01ad026cf98f4285b68fR275-R284) [[2]](diffhunk://#diff-821850501f13006ad39cfb3322383c570b9a09be6bef01ad026cf98f4285b68fR408-R417)

* Updated the `as_workflow_execution_dict` method to use the new `started_at_time` and `ended_at_time` properties instead of directly accessing the workflow state. This improves encapsulation and code readability. (`nmdc_automation/workflow_automation/wfutils.py`)

### Test updates:

* Modified the `test_jaws_workflow_job_as_workflow_execution_dict` test to include an assertion for the `ended_at_time` field, ensuring the new metadata properties work as expected. (`tests/test_wfutils.py`)