### PR TITLE
implement version comparison change

### DIFF
--- a/nmdc_automation/workflow_automation/workflow_process.py
+++ b/nmdc_automation/workflow_automation/workflow_process.py
@@ -36,17 +36,20 @@ def get_required_data_objects_map(db, workflows: List[WorkflowConfig]) -> Dict[s
 @lru_cache
 def _within_range(ver1: str, ver2: str) -> bool:
     """
-    Determine if two workflows are within a major and minor
-    version of each other.
-    """
+    Determine if the version of the workflow is within the range of the
+    version of the workflow execution record. This is used to determine if the
+    workflow execution record satisfies the version of the workflow. If the execution
+    record is not within the range, that workflow will be re-processed.
 
+    The current rule is that if the major version is the same, then it is within the range.
+    """
     def get_version(version):
         v_string = version.lstrip("b").lstrip("v").rstrip("-beta")
         return Version.parse(v_string)
 
     v1 = get_version(ver1)
     v2 = get_version(ver2)
-    if v1.major == v2.major and v1.minor == v2.minor:
+    if v1.major == v2.major:
         return True
     return False
 

--- a/tests/fixtures/nmdc_db/workflow_execution_2.json
+++ b/tests/fixtures/nmdc_db/workflow_execution_2.json
@@ -36,7 +36,7 @@
       "nmdc:dobj-11-mbr36m97"
     ],
     "type": "nmdc:MetagenomeAnnotation",
-    "version": "v1.0.4",
+    "version": "v0.9.4",
     "gold_analysis_project_identifiers": [
     ]
   },
@@ -134,7 +134,7 @@
       "nmdc:dobj-11-azjee549"
     ],
     "type": "nmdc:MagsAnalysis",
-    "version": "v1.0.6",
+    "version": "v0.9.5",
     "mags_list": [
     ]
   },
@@ -171,7 +171,7 @@
       "nmdc:dobj-11-kjnzfq20"
     ],
     "type": "nmdc:MagsAnalysis",
-    "version": "v1.0.6",
+    "version": "v0.9.6",
     "mags_list": [
     ]
   },

--- a/tests/test_workflow_process.py
+++ b/tests/test_workflow_process.py
@@ -253,5 +253,16 @@ def test_get_required_data_objects_by_id(test_db, workflows_config_dir, workflow
         assert do_type in do_types
 
 def test_within_range():
+    """
+    Test that the version is within the range.
+    """
+    # Exact match
     assert _within_range('v1.0.8', 'v1.0.8')
+    # Patch version
     assert _within_range('v1.0.8', 'v1.0.9')
+    assert _within_range('v1.0.8', 'v1.0.7')
+    # Minor version
+    assert _within_range('v1.0.8', 'v1.1.0')
+    assert _within_range('v1.0.8', 'v1.0.0')
+    # Major version - out of range
+    assert not _within_range('v1.0.8', 'v2.0.0')


### PR DESCRIPTION
This pull request refines the version comparison logic for workflows and updates related tests and fixtures. The most important changes include modifying the `_within_range` function to simplify the version comparison rule, updating test fixtures to reflect new versioning, and adding comprehensive test cases for the updated logic.

### Changes to version comparison logic:

* [`nmdc_automation/workflow_automation/workflow_process.py`](diffhunk://#diff-cc2dbde75771b37c4c716d5a55fade0d598bcffd15238ae7cdaa243bdb15ebe2L39-R52): Simplified the `_within_range` function to consider workflows within the same major version as "within range," removing the minor version constraint. Updated the docstring to reflect the new rule.

### Updates to test fixtures:

* [`tests/fixtures/nmdc_db/workflow_execution_2.json`](diffhunk://#diff-6134a789222a7d9e473fd7cd8d0e4568fbb1e4e96b31edcc945123a93aff1f72L39-R39): Updated the `version` fields in multiple fixtures to use earlier versions (`v0.9.x`) to align with the new version comparison logic. [[1]](diffhunk://#diff-6134a789222a7d9e473fd7cd8d0e4568fbb1e4e96b31edcc945123a93aff1f72L39-R39) [[2]](diffhunk://#diff-6134a789222a7d9e473fd7cd8d0e4568fbb1e4e96b31edcc945123a93aff1f72L137-R137) [[3]](diffhunk://#diff-6134a789222a7d9e473fd7cd8d0e4568fbb1e4e96b31edcc945123a93aff1f72L174-R174)

### Enhancements to test cases:

* [`tests/test_workflow_process.py`](diffhunk://#diff-255678bdafd88c37b2eb835feacce4a82ffb8f89ac9e269493d99afdfc49b9c5R256-R268): Added detailed test cases for `_within_range` to validate the new major-version-only rule, including scenarios for exact matches, patch versions, minor versions, and out-of-range major versions.