### PR TITLE
Update workflow.last_status property to always return a string

### DIFF
--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -506,8 +506,8 @@ class WorkflowStateManager:
         return self.cached_state.get("conf", self.cached_state.get("config", {}))
 
     @property
-    def last_status(self) -> Optional[str]:
-        return self.cached_state.get("last_status", None)
+    def last_status(self) -> str:
+        return self.cached_state.get("last_status", "unknown")
 
     @last_status.setter
     def last_status(self, status: str):


### PR DESCRIPTION
- return "unknown" for cases where last status cannot be determined from the state file

Addresses #517 