### PR TITLE
537-issues-with-multiples

### DIFF
--- a/nmdc_automation/import_automation/import_mapper.py
+++ b/nmdc_automation/import_automation/import_mapper.py
@@ -411,7 +411,8 @@ class DataObjectMapping:
             )
 
     def __hash__(self):
-        return hash((self.data_object_type, self.import_file, self.output_of, self.data_object_id, self.nmdc_process_id, self.data_category))
+        return hash((self.data_object_type, self.import_file, self.output_of, self.data_object_id,
+                     self.nmdc_process_id, str(self.data_category)))
         
 
 @lru_cache

--- a/nmdc_automation/import_automation/import_mapper.py
+++ b/nmdc_automation/import_automation/import_mapper.py
@@ -130,7 +130,7 @@ class ImportMapper:
         """Return the import specifications by data object type (unique and multiple)."""
         import_specs = {do['data_object_type']: do for do in self.import_specifications["Data Objects"]["Unique"]}
         import_specs.update(
-            {do['data_object_type']: do for do in self.import_specifications["Data Objects"]["Multiples"]}
+            {do['data_object_type']: do for do in self.import_specifications["Data Objects"].get("Multiples", [])}
             )
         return import_specs
 


### PR DESCRIPTION
Update import_specs_by_date_object_type to use get("Multiples")
MT imports do not contain multi-part data objects

This pull request includes a small but important change to the `import_specs_by_data_object_type` method in `nmdc_automation/import_automation/import_mapper.py`. The change ensures that the code handles cases where the "Multiples" key might be missing in the `import_specifications` dictionary by using the `get` method with a default empty list.

- Updated the dictionary comprehension for "Multiples" to use `.get("Multiples", [])`, ensuring the method does not raise a `KeyError` if the "Multiples" key is absent. (`[nmdc_automation/import_automation/import_mapper.pyL133-R133](diffhunk://#diff-3af3c4d28793c6a584dd7e81c4aef049acd33b3b01f68652bb5c69478a72d0bfL133-R133)`)