### PR TITLE
Fix missing ended at time

### DIFF
--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -818,7 +818,6 @@ class WorkflowJob:
         """
         wf_dict = self.as_workflow_execution_dict
         wf_dict["has_output"] = [dobj.id for dobj in data_objects]
-        wf_dict["ended_at_time"] = self.job.metadata.get("end")
 
         # workflow-specific keys
         logical_names = set()

--- a/tests/test_wfutils.py
+++ b/tests/test_wfutils.py
@@ -427,3 +427,21 @@ def test_workflow_job_from_database_job_record(site_config, fixtures_dir):
     job = WorkflowJob(site_config, job_rec)
     assert job
     assert job.workflow.nmdc_jobid == job_rec['id']
+
+
+@pytest.mark.parametrize("fixture_pair", [
+    ("mags_workflow_state.json", "mags_jaws_status.json"),
+    ("annotation_workflow_state.json", "annotation_jaws_status.json"),
+    ("meta_assembly_workflow_state.json", "meta_assembly_jaws_status.json"),
+    ("read_based_analysis_workflow_state.json", "read_based_analysis_jaws_status.json"),
+    ("rqc_workflow_state.json", "rqc_jaws_status.json"),
+])
+def test_jaws_workflow_execution_record_has_ended_at_time(fixture_pair, site_config, fixtures_dir, mock_jaws_api,
+                                                       tmp_path):
+    workflow_state = json.load(open(fixtures_dir / fixture_pair[0]))
+    job_metadata = json.load(open(fixtures_dir / fixture_pair[1]))
+
+    wfj = WorkflowJob(site_config, workflow_state, job_metadata, jaws_api=mock_jaws_api)
+    wfe = wfj.make_workflow_execution([])
+    assert wfe.started_at_time
+    assert wfe.ended_at_time


### PR DESCRIPTION
This pull request introduces changes to enhance the handling of workflow execution records and adds new test coverage for verifying the presence of `ended_at_time` in workflow execution objects. The most important changes include modifying the `make_workflow_execution` method and adding parameterized tests for various workflow states.

### Enhancements to workflow execution handling:

* [`nmdc_automation/workflow_automation/wfutils.py`](diffhunk://#diff-821850501f13006ad39cfb3322383c570b9a09be6bef01ad026cf98f4285b68fL821): Removed the assignment of `ended_at_time` from job metadata in the `make_workflow_execution` method, likely to shift the responsibility for determining `ended_at_time` to another part of the workflow logic.

### Expanded test coverage:

* [`tests/test_wfutils.py`](diffhunk://#diff-6bf12628a7ffef9b88f14aa6259c4ec2b319c50171311931d3de807807e72a46R430-R447): Added a parameterized test `test_jaws_workflow_execution_record_has_ended_at_time` to ensure that `WorkflowExecution` objects correctly include both `started_at_time` and `ended_at_time` for multiple workflow scenarios. This test uses fixtures to validate the behavior across different workflow states and job metadata.