### PR TITLE
Remove references to minter bind endpoint

### DIFF
--- a/nmdc_automation/api/nmdcapi.py
+++ b/nmdc_automation/api/nmdcapi.py
@@ -140,12 +140,6 @@ class NmdcRuntimeApi:
             logging.error(f"Response failed for: url: {url}, data: {data}, header: {self.header}")
             raise ValueError(f"Failed to mint ID of type {id_type} HTTP status: {resp.status_code} / ({resp.reason})")
         id = resp.json()[0]
-        if informed_by:
-            url = f"{self._base_url}pids/bind"
-            data = {"id_name": id, "metadata_record": {"informed_by": informed_by}}
-            resp = requests.post(url, data=json.dumps(data), headers=self.header)
-            if not resp.ok:
-                raise ValueError("Failed to bind metadata to pid")
         return id
 
     @retry(wait=wait_exponential(multiplier=4, min=8, max=120), stop=stop_after_attempt(6), reraise=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,7 +91,6 @@ def mock_api(monkeypatch, requests_mock, test_data_dir):
         "http://localhost:8000/workflows/workflow_executions",
         json=resp
         )
-    requests_mock.post("http://localhost:8000/pids/bind", json=resp)
 
     rqcf = test_data_dir / "rqc_response2.json"
     rqc = json.load(open(rqcf))


### PR DESCRIPTION
This PR removes references the endpoint to bind IDs. This endpoint was written initially and has not been used, IDs are automatically bound when they get submitted to mongo so this step is not necessary. Removing this will help with deprecating endpoints that aren't used in nmdc-runtime.