### PR TITLE
Bump ReadsQC to v1.0.20

### DIFF
--- a/nmdc_automation/config/workflows/workflows.yaml
+++ b/nmdc_automation/config/workflows/workflows.yaml
@@ -19,7 +19,7 @@ Workflows:
     Enabled: True
     Analyte Category: Metagenome
     Git_repo: https://github.com/microbiomedata/ReadsQC
-    Version: v1.0.20
+    Version: v1.0.14
     WDL: rqcfilter.wdl
     Collection: workflow_execution_set
     Filter Input Objects:


### PR DESCRIPTION
This is a version bump for reads qc required to address issues found in manifest_set testing 

related to https://github.com/microbiomedata/nmdc_automation/issues/623