### PR TITLE
Fixing get.requests to not expect a body. Note that the local endpoin…

### DIFF
--- a/nmdc_automation/api/nmdcapi.py
+++ b/nmdc_automation/api/nmdcapi.py
@@ -322,15 +322,20 @@ class NmdcRuntimeApi:
     @retry(wait=wait_exponential(multiplier=4, min=8, max=120), stop=stop_after_attempt(6), reraise=True)
     @refresh_token
     def list_jobs(self, filt=None, max=100) -> List[dict]:
-        url = "%sjobs?max_page_size=%s" % (self._base_url, max)
-        d = {}
+        url = "%sjobs" % (self._base_url) 
+
+        params = {
+            "max_page_size": max
+        }
         if filt:
-            url += "&filter=%s" % (json.dumps(filt))
-        orig_url = url
+            #url += "&filter=%s" % (json.dumps(filt))
+            params["filter"] = json.dumps(filt)
+        
         results = []
         while True:
-            resp = requests.get(url, data=json.dumps(d), headers=self.header)
+            resp = requests.get(url, headers=self.header, params=params)
             if resp.status_code != 200:
+                # todo make this exit with failure more cleanly -jlp 20251104
                 resp.raise_for_status()
             try:
                 response_json = resp.json()
@@ -414,13 +419,12 @@ class NmdcRuntimeApi:
     @refresh_token
     def list_ops(self, filt=None, max_page_size=40):
         url = "%soperations?max_page_size=%d" % (self._base_url, max_page_size)
-        d = {}
         if filt:
             url += "&filter=%s" % (json.dumps(filt))
         orig_url = url
         results = []
         while True:
-            resp = requests.get(url, data=json.dumps(d), headers=self.header).json()
+            resp = requests.get(url, headers=self.header).json()
             if "resources" not in resp:
                 logging.warning(str(resp))
                 break


### PR DESCRIPTION
Fixing nmdcapi.py's GET requests to not expect a body, else 400 HTTPError is returned by GCP-hosted runtime API. Local runtime tests happily returns the request with 200 OK even if an empty body is set, as the HTTP standards are not enforced in this environment (and possibly on SPIN from tests that predate me). 
Cleaned up the logic related to pagination that would introduce another bug.