### PR TITLE
bug fix to properly order the api params for RuntimeApiHandler

### DIFF
--- a/nmdc_automation/workflow_automation/watch_nmdc.py
+++ b/nmdc_automation/workflow_automation/watch_nmdc.py
@@ -334,7 +334,7 @@ class JobManager:
 
 class RuntimeApiHandler:
     """ RuntimeApiHandler class for managing API calls to the runtime """
-    def __init__(self, config, runtime_api=None, jaws_api=None):
+    def __init__(self, config, jaws_api=None, runtime_api=None):
         #self.runtime_api = NmdcRuntimeApi(config)
         self.config = config
         # Updated to handle passed in api (for example test fixture), else initialize like usual

--- a/tests/test_watch_nmdc.py
+++ b/tests/test_watch_nmdc.py
@@ -493,7 +493,7 @@ def test_runtime_manager_get_unclaimed_jobs(site_config, test_data_dir, test_db,
             )
 
             # 4. Initialize and Run the test within the Mocker context
-            rt = RuntimeApiHandler(site_config, runtime_api=n)
+            rt = RuntimeApiHandler(site_config, jaws_api=None, runtime_api=n)
 
             # Act
             unclaimed_jobs = rt.get_unclaimed_jobs(rt.config.allowed_workflows)
@@ -501,7 +501,7 @@ def test_runtime_manager_get_unclaimed_jobs(site_config, test_data_dir, test_db,
             # Assert
             assert unclaimed_jobs
     else:
-        rt = RuntimeApiHandler(site_config, runtime_api=n)
+        rt = RuntimeApiHandler(site_config, jaws_api=None, runtime_api=n)
 
         # Act
         unclaimed_jobs = rt.get_unclaimed_jobs(rt.config.allowed_workflows)
@@ -535,3 +535,4 @@ def test_watcher_restore_from_checkpoint_and_report(site_config_file, fixtures_d
     assert rpt
     assert rpt['wdl'] == "mbin_nmdc.wdl"
     assert rpt['last_status'] == "Failed"
+


### PR DESCRIPTION
Fix to address bug found in testing in mishandling of runtime and jaws api parameters to RuntimeApiHandler class in production setting. 