### PR TITLE
Update read based taxonomy workflow to use SingleM

### DIFF
--- a/nmdc_automation/config/workflows/workflows.yaml
+++ b/nmdc_automation/config/workflows/workflows.yaml
@@ -422,10 +422,10 @@ Workflows:
       description: Kraken2 Krona for {id}
       name: Kraken2 Krona plot HTML file
     - output: final_singlem_classification_tsv
-      data_object_type: SingleM Taxonomic Classification	
+      data_object_type: SingleM Taxonomic Classification
       description: SingleM Classification for {id}
       name: SingleM classification file
-    - output: final_singlem_report_tsv  
+    - output: final_singlem_report_tsv
       data_object_type: SingleM Clustered Report
       description: SingleM Clustered Report for {id}
       name: SingleM clustered report file


### PR DESCRIPTION
Updated version to v1.1.0 and added SingleM outputs. For now it keeps all optional output files. We'll update import automation later since we don't have any JGI results in jamo yet.