### PR TITLE
fix downstream manifest workflow execution records and failed ct bug

### DIFF
--- a/nmdc_automation/workflow_automation/watch_nmdc.py
+++ b/nmdc_automation/workflow_automation/watch_nmdc.py
@@ -244,7 +244,6 @@ class JobManager:
                     continue
                 elif status in ("failed", "null"):
                     job.workflow.last_status = status
-                    job.workflow.failed_count += 1
                     failed_jobs.append(job)
                     continue
                 else:

--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -176,6 +176,7 @@ class JawsRunner(JobRunnerABC):
             elif len(self.workflow.was_informed_by) == 1:
                 tag_value = self.workflow.was_informed_by[0] + "/" + self.workflow.workflow_execution_id
             
+            # This will work to schedule but shouldn't go to this block unless bug or new feature support
             else:
                 tag_value = ":".join(self.workflow.was_informed_by) + "/" + self.workflow.workflow_execution_id
 

--- a/tests/fixtures/nmdc_db/data_objects_in_manifest_downstream.json
+++ b/tests/fixtures/nmdc_db/data_objects_in_manifest_downstream.json
@@ -1,0 +1,86 @@
+[
+  {
+    "data_object_type": "Metagenome Raw Read 1",
+    "description": "sequencing results for BMI_HCNKKBGX5_Tube93_R1",
+    "id": "nmdc:dobj-11-ryqm4v52",
+    "in_manifest": [
+      "nmdc:manif-11-behhtd03"
+    ],
+    "name": "BMI_HCNKKBGX5_Tube93_R1.fastq.gz",
+    "type": "nmdc:DataObject",
+    "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube93_R1.fastq.gz",
+    "data_category": "instrument_data"
+  },
+  {
+    "data_object_type": "Metagenome Raw Read 2",
+    "description": "sequencing results for BMI_HCNKKBGX5_Tube93_R2",
+    "id": "nmdc:dobj-11-g8xx8612",
+    "in_manifest": [
+      "nmdc:manif-11-behhtd03"
+    ],
+    "name": "BMI_HCNKKBGX5_Tube93_R2.fastq.gz",
+    "type": "nmdc:DataObject",
+    "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube93_R2.fastq.gz",
+    "data_category": "instrument_data"
+  },
+  {
+    "data_object_type": "Metagenome Raw Read 1",
+    "description": "sequencing results for BMI_HLGJLBGX5_Tube93_R1",
+    "id": "nmdc:dobj-11-t63mfm30",
+    "in_manifest": [
+      "nmdc:manif-11-behhtd03"
+    ],
+    "name": "BMI_HLGJLBGX5_Tube93_R1.fastq.gz",
+    "type": "nmdc:DataObject",
+    "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube93_R1.fastq.gz",
+    "data_category": "instrument_data"
+  },
+  {
+    "data_object_type": "Metagenome Raw Read 2",
+    "description": "sequencing results for BMI_HLGJLBGX5_Tube93_R2",
+    "id": "nmdc:dobj-11-qseqfc93",
+    "in_manifest": [
+      "nmdc:manif-11-behhtd03"
+    ],
+    "name": "BMI_HLGJLBGX5_Tube93_R2.fastq.gz",
+    "type": "nmdc:DataObject",
+    "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube93_R2.fastq.gz",
+    "data_category": "instrument_data"
+  },
+  {
+  "id": "nmdc:dobj-15-fkq3hr62",
+  "type": "nmdc:DataObject",
+  "name": "nmdc_wfrqc-15-8rcjpy94.1_filtered.fastq.gz",
+  "description": "Reads QC for nmdc:wfrqc-15-8rcjpy94.1",
+  "data_category": "processed_data",
+  "data_object_type": "Filtered Sequencing Reads",
+  "file_size_bytes": 1784035188,
+  "md5_checksum": "24106eaa91ec4d02e4287bffccaf020a",
+  "url": "https://data.microbiomedata.org/data/dev/nmdc:manif-11-behhtd03/nmdc:wfrqc-15-8rcjpy94.1/nmdc_wfrqc-15-8rcjpy94.1_filtered.fastq.gz",
+  "was_generated_by": "nmdc:wfrqc-15-8rcjpy94.1"
+  },
+  {
+  "id": "nmdc:dobj-15-kfhkdy33",
+  "type": "nmdc:DataObject",
+  "name": "nmdc_wfrqc-15-8rcjpy94.1_readsQC.info",
+  "description": "Read filtering info for nmdc:wfrqc-15-8rcjpy94.1",
+  "data_category": "processed_data",
+  "data_object_type": "Read Filtering Info File",
+  "file_size_bytes": 620,
+  "md5_checksum": "436b791048f5c24824d1a29b02e6004b",
+  "url": "https://data.microbiomedata.org/data/dev/nmdc:manif-11-behhtd03/nmdc:wfrqc-15-8rcjpy94.1/nmdc_wfrqc-15-8rcjpy94.1_readsQC.info",
+  "was_generated_by": "nmdc:wfrqc-15-8rcjpy94.1"
+  },
+ {
+  "id": "nmdc:dobj-15-xgvmvk15",
+  "type": "nmdc:DataObject",
+  "name": "nmdc_wfrqc-15-8rcjpy94.1_filterStats.txt",
+  "description": "Reads QC summary for nmdc:wfrqc-15-8rcjpy94.1",
+  "data_category": "processed_data",
+  "data_object_type": "QC Statistics",
+  "file_size_bytes": 282,
+  "md5_checksum": "1700fd3f1762f48fc74525ead9f510c1",
+  "url": "https://data.microbiomedata.org/data/dev/nmdc:manif-11-behhtd03/nmdc:wfrqc-15-8rcjpy94.1/nmdc_wfrqc-15-8rcjpy94.1_filterStats.txt",
+  "was_generated_by": "nmdc:wfrqc-15-8rcjpy94.1"
+ }
+]

--- a/tests/fixtures/nmdc_db/job_manifest_readsqc.json
+++ b/tests/fixtures/nmdc_db/job_manifest_readsqc.json
@@ -1,0 +1,123 @@
+[{
+  "workflow": {
+    "id": "Reads QC Interleave: v1.0.20"
+  },
+  "id": "nmdc:sys0xpy42947",
+  "created_at": {
+    "$date": "2025-11-25T19:21:34.870Z"
+  },
+  "config": {
+    "git_repo": "https://github.com/microbiomedata/ReadsQC",
+    "release": "v1.0.20",
+    "wdl": "interleave_rqcfilter.wdl",
+    "activity_id": "nmdc:wfrqc-15-8rcjpy94.1",
+    "activity_set": "workflow_execution_set",
+    "was_informed_by": [
+      "nmdc:dgns-11-qmpge038",
+      "nmdc:dgns-11-w99dsv77"
+    ],
+    "trigger_activity": "nmdc:dgns-11-qmpge038",
+    "iteration": 1,
+    "input_prefix": "nmdc_rqcfilter",
+    "inputs": {
+      "proj": "nmdc:wfrqc-15-8rcjpy94.1",
+      "input_fastq1": [
+        "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube93_R1.fastq.gz",
+        "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube93_R1.fastq.gz"
+      ],
+      "input_fastq2": [
+        "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube93_R2.fastq.gz",
+        "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube93_R2.fastq.gz"
+      ]
+    },
+    "input_data_objects": [
+      {
+        "id": "nmdc:dobj-11-ryqm4v52",
+        "type": "nmdc:DataObject",
+        "name": "BMI_HCNKKBGX5_Tube93_R1.fastq.gz",
+        "description": "sequencing results for BMI_HCNKKBGX5_Tube93_R1",
+        "data_category": "instrument_data",
+        "data_object_type": "Metagenome Raw Read 1",
+        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube93_R1.fastq.gz",
+        "in_manifest": [
+          "nmdc:manif-11-behhtd03"
+        ]
+      },
+      {
+        "id": "nmdc:dobj-11-t63mfm30",
+        "type": "nmdc:DataObject",
+        "name": "BMI_HLGJLBGX5_Tube93_R1.fastq.gz",
+        "description": "sequencing results for BMI_HLGJLBGX5_Tube93_R1",
+        "data_category": "instrument_data",
+        "data_object_type": "Metagenome Raw Read 1",
+        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube93_R1.fastq.gz",
+        "in_manifest": [
+          "nmdc:manif-11-behhtd03"
+        ]
+      },
+      {
+        "id": "nmdc:dobj-11-g8xx8612",
+        "type": "nmdc:DataObject",
+        "name": "BMI_HCNKKBGX5_Tube93_R2.fastq.gz",
+        "description": "sequencing results for BMI_HCNKKBGX5_Tube93_R2",
+        "data_category": "instrument_data",
+        "data_object_type": "Metagenome Raw Read 2",
+        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube93_R2.fastq.gz",
+        "in_manifest": [
+          "nmdc:manif-11-behhtd03"
+        ]
+      },
+      {
+        "id": "nmdc:dobj-11-qseqfc93",
+        "type": "nmdc:DataObject",
+        "name": "BMI_HLGJLBGX5_Tube93_R2.fastq.gz",
+        "description": "sequencing results for BMI_HLGJLBGX5_Tube93_R2",
+        "data_category": "instrument_data",
+        "data_object_type": "Metagenome Raw Read 2",
+        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube93_R2.fastq.gz",
+        "in_manifest": [
+          "nmdc:manif-11-behhtd03"
+        ]
+      }
+    ],
+    "activity": {
+      "name": "Read QC for {id}",
+      "input_read_bases": "{outputs.stats.input_read_bases}",
+      "input_read_count": "{outputs.stats.input_read_count}",
+      "output_read_bases": "{outputs.stats.output_read_bases}",
+      "output_read_count": "{outputs.stats.output_read_count}",
+      "type": "nmdc:ReadQcAnalysis"
+    },
+    "outputs": [
+      {
+        "output": "filtered_final",
+        "name": "Reads QC result fastq (clean data)",
+        "data_object_type": "Filtered Sequencing Reads",
+        "description": "Reads QC for {id}",
+        "id": "nmdc:dobj-15-fkq3hr62"
+      },
+      {
+        "output": "filtered_stats_final",
+        "name": "Reads QC summary statistics",
+        "data_object_type": "QC Statistics",
+        "description": "Reads QC summary for {id}",
+        "id": "nmdc:dobj-15-xgvmvk15"
+      },
+      {
+        "output": "rqc_info",
+        "name": "File containing read filtering information",
+        "data_object_type": "Read Filtering Info File",
+        "description": "Read filtering info for {id}",
+        "id": "nmdc:dobj-15-kfhkdy33"
+      }
+    ],
+    "manifest": "nmdc:manif-11-behhtd03"
+  },
+  "claims": [
+    {
+      "op_id": "nmdc:sys0k8437h45",
+      "site_id": "NERSC"
+    }
+  ]
+ }
+]

--- a/tests/fixtures/nmdc_db/workflow_execution_manifest_asm.json
+++ b/tests/fixtures/nmdc_db/workflow_execution_manifest_asm.json
@@ -1,0 +1,28 @@
+[
+  {
+  "id": "nmdc:wfrqc-15-8rcjpy94.1",
+  "type": "nmdc:ReadQcAnalysis",
+  "name": "Read QC for nmdc:wfrqc-15-8rcjpy94.1",
+  "has_input": [
+    "nmdc:dobj-11-ryqm4v52",
+    "nmdc:dobj-11-t63mfm30",
+    "nmdc:dobj-11-g8xx8612",
+    "nmdc:dobj-11-qseqfc93"
+  ],
+  "has_output": [
+    "nmdc:dobj-15-fkq3hr62",
+    "nmdc:dobj-15-xgvmvk15",
+    "nmdc:dobj-15-kfhkdy33"
+  ],
+  "processing_institution": "NMDC",
+  "git_url": "https://github.com/microbiomedata/ReadsQC",
+  "started_at_time": "2025-11-25 11:31:14",
+  "was_informed_by": [
+    "nmdc:dgns-11-qmpge038",
+    "nmdc:dgns-11-w99dsv77"
+  ],
+  "ended_at_time": "2025-11-25 13:41:21",
+  "execution_resource": "NERSC-Perlmutter",
+  "version": "v1.0.20"
+  }
+]


### PR DESCRIPTION
Scheduler needs manifest_id set for wfp_node in get_current_workflow_process_nodes when was_informed_by is multi-valued for non-data generation set wfp nodes.. Previous implementation only set manifest for the data_generation_set wfp_nodes. 
Bug fix - Removed double counting of failed jobs in watcher get_finished_jobs so that the failed count is only handled by the process_failed_jobs function.