### PR TITLE
moving another verbose log statements to debug

### DIFF
--- a/nmdc_automation/workflow_automation/workflow_process.py
+++ b/nmdc_automation/workflow_automation/workflow_process.py
@@ -516,7 +516,7 @@ def _map_manifest_to_data_generation_set(api, manifest_map):
     }
 
     resp = api.run_query(data_object_agg)
-    logging.info(f"queries:run response: {resp}")
+    logging.debug(f"queries:run response: {resp}")
         
     # Log any issues
     if len(resp) == 0:


### PR DESCRIPTION
another quick cleanup so sched.log isn't too verbose.