### PR TITLE
update to job_rec creation for sched for readsqc with single inputs

### DIFF
--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -192,8 +192,12 @@ class Scheduler:
                 
                     if k == "input_files":
                         v = [dobj_list[0]["url"]]
+                    elif k in ["input_fastq1", "input_fastq2"]:  
+                        v = [dobj_list[0]["url"]]
                     else:
                         v = dobj_list[0]["url"]
+                
+                # For multi-input, it goes here to produce []
                 else:
                     v = []
                     for dobj in dobj_list:


### PR DESCRIPTION
The sched `create_job_rec` logic needed to specifically handle conversion of single file inputs to array in support of the input change from string to array[string] in interleave_rqcfilter.wdl for non-manifest data sets.