### PR TITLE
Adding some retry and timeout logic to list_from_collection to handle…

### DIFF
--- a/nmdc_automation/api/nmdcapi.py
+++ b/nmdc_automation/api/nmdcapi.py
@@ -78,6 +78,10 @@ class NmdcRuntimeApi:
         self.session = requests.Session()
         retries = Retry(
             total=6,
+            # Explicitly handle network-level issues
+            connect=3,  # how many connection-related errors to retry
+            read=3,     # how many times to retry on read errors (timeouts)
+            status=3,   # how many times to retry on the status_forcelist
             backoff_factor=3,
             status_forcelist=[429, 500, 502, 503, 504],
             raise_on_redirect=False,

--- a/tests/test_nmdcapi.py
+++ b/tests/test_nmdcapi.py
@@ -285,8 +285,6 @@ def test_list_from_collection_pagination(monkeypatch, requests_mock, test_client
     n.session = requests.Session()
 
     collection = "data_object_set"
-    base_url = "http://localhost:8000/nmdcschema/"
-    url = f"{base_url}{collection}"
 
     # Temporarily bind the REAL method to the mock instance
     monkeypatch.setattr(n, "list_from_collection", nmdcapi.list_from_collection.__get__(n, nmdcapi))
@@ -367,8 +365,7 @@ def test_list_from_collection_error_handling(monkeypatch, requests_mock, test_cl
     n.session = requests.Session()
 
     collection = "data_object_set"
-    url = f"http://localhost:8000/nmdcschema/{collection}"
-
+    
     monkeypatch.setattr(n, "list_from_collection", nmdcapi.list_from_collection.__get__(n, nmdcapi))
 
     # Simulate a successful first page followed by a 400 Bad Request (Invalid Token)


### PR DESCRIPTION
Implemented session retry logic in `NmdcRuntimeApi` using `urllib3` `Retry` strategy (6 retries with exponential backoff). Updated `list_from_collection` to use `raise_for_status()` and added exception handling to prevent returning partial data on failure. Added `timeout` to GET requests to prevent hanging during network instability. Added 3 tests to test the pagination, retry loop, and exception handling.

