### PR TITLE
Fix scheduler job creation for array of files (input_fq1, input_fq2)

### DIFF
--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -192,9 +192,7 @@ class Scheduler:
                 if len(dobj_list) == 1:
                     input_data_objects.append(dobj_list[0].as_dict())
                 
-                    if k == "input_files":
-                        v = [dobj_list[0]["url"]]
-                    elif k in ["input_fastq1", "input_fastq2"]:  
+                    if k in ["input_files", "input_fq1", "input_fq2", "input_fastq1", "input_fastq2"]:
                         v = [dobj_list[0]["url"]]
                     else:
                         v = dobj_list[0]["url"]

--- a/tests/fixtures/manifest_workflow_state.json
+++ b/tests/fixtures/manifest_workflow_state.json
@@ -19,11 +19,11 @@
     "input_prefix": "nmdc_rqcfilter",
     "inputs": {
       "proj": "nmdc:wfrqc-12-mecph171.1",
-      "input_fastq1": [
+      "input_fq1": [
         "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube93_R1.fastq.gz",
         "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube93_R1.fastq.gz"
       ],
-      "input_fastq2": [
+      "input_fq2": [
         "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube93_R2.fastq.gz",
         "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube93_R2.fastq.gz"
       ]

--- a/tests/fixtures/manifest_workflow_state_2.json
+++ b/tests/fixtures/manifest_workflow_state_2.json
@@ -19,11 +19,11 @@
     "input_prefix": "nmdc_rqcfilter",
     "inputs": {
       "proj": "nmdc:wfrqc-12-mecph171.1",
-      "input_fastq1": [
+      "input_fq1": [
         "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube93_R1.fastq.gz",
         "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube93_R1.fastq.gz"
       ],
-      "input_fastq2": [
+      "input_fq2": [
         "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube93_R2.fastq.gz",
         "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube93_R2.fastq.gz"
       ]

--- a/tests/fixtures/nmdc_db/job_manifest_3_readsqc.json
+++ b/tests/fixtures/nmdc_db/job_manifest_3_readsqc.json
@@ -22,11 +22,11 @@
     "input_prefix": "nmdc_rqcfilter",
     "inputs": {
       "proj": "nmdc:wfrqc-15-x027k720.1",
-      "input_fastq1": [
+      "input_fq1": [
         "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HNFFKBGXN_R1/BMI_22A_01_0002_mms_HNFFKBGXN_R1.fastq.gz",
         "https://storage.neonscience.org/neon-microbial-raw-seq-files/2024/HTLW3DSX7_PoolA_R1/BMI_22A_01_0002_R1.fastq.gz"
       ],
-      "input_fastq2": [
+      "input_fq2": [
         "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HNFFKBGXN_R2/BMI_22A_01_0002_mms_HNFFKBGXN_R2.fastq.gz",
         "https://storage.neonscience.org/neon-microbial-raw-seq-files/2024/HTLW3DSX7_PoolA_R2/BMI_22A_01_0002_R2.fastq.gz"
       ]

--- a/tests/fixtures/nmdc_db/job_manifest_readsqc.json
+++ b/tests/fixtures/nmdc_db/job_manifest_readsqc.json
@@ -21,11 +21,11 @@
     "input_prefix": "rqcfilter",
     "inputs": {
       "proj": "nmdc:wfrqc-15-8rcjpy94.1",
-      "input_fastq1": [
+      "input_fq1": [
         "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube93_R1.fastq.gz",
         "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube93_R1.fastq.gz"
       ],
-      "input_fastq2": [
+      "input_fq2": [
         "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube93_R2.fastq.gz",
         "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube93_R2.fastq.gz"
       ]

--- a/tests/fixtures/rqc_workflow_state.json
+++ b/tests/fixtures/rqc_workflow_state.json
@@ -15,8 +15,8 @@
     "input_prefix": "nmdc_rqcfilter",
     "inputs": {
       "proj": "nmdc:wfrqc-12-s66ntc59.1",
-      "input_fastq1": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/argonne_R1/DSNY_009-M-33-14-20140409-gen_R1.fastq.gz",
-      "input_fastq2": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/argonne_R2/DSNY_009-M-33-14-20140409-gen_R2.fastq.gz"
+      "input_fq1": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/argonne_R1/DSNY_009-M-33-14-20140409-gen_R1.fastq.gz",
+      "input_fq2": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/argonne_R2/DSNY_009-M-33-14-20140409-gen_R2.fastq.gz"
     },
     "input_data_objects": [
       {

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -347,23 +347,32 @@ def test_scheduler_create_job_rec_raises_missing_data_object_exception(test_db, 
 #def test_scheduler_create_job_rec_has_input_files_as_array(test_db, mock_api, workflows_config_dir, site_config_file):
 def test_scheduler_create_job_rec_has_input_files_as_array(test_db, test_client, workflows_config_dir, site_config_file):
     """
-    Test that the input_data_objects field is an array of strings.
+    Test that input_fq1/input_fq2 (Reads QC Interleave) and input_files (Assembly)
+    are arrays, not plain strings. Regression test for the nohup error where
+    input_fq1/input_fq2 were passed as strings instead of Array[String].
     """
     reset_db(test_db)
     load_fixture(test_db, "data_object_set.json")
     load_fixture(test_db, "data_generation_set.json")
-    load_fixture(test_db, "read_qc_analysis.json", col="workflow_execution_set")
 
-    #jm = Scheduler(
-    #    test_db, workflow_yaml=workflows_config_dir / "workflows.yaml",
-    #    site_conf=site_config_file
-    #    )
     jm = Scheduler(
         workflow_yaml=workflows_config_dir / "workflows.yaml",
-        site_conf=site_config_file, 
+        site_conf=site_config_file,
         api=test_client
         )
 
+    # Cycle 1: no RQC output loaded yet, so scheduler creates the Reads QC Interleave job.
+    # This is where input_fq1/input_fq2 are assigned — assert they are lists not plain strings.
+    resp = jm.cycle()
+    rqc_jobs = [j for j in resp if j["config"]["activity"]["type"] == "nmdc:ReadQcAnalysis"]
+    assert rqc_jobs
+    rqc_job = rqc_jobs[0]
+    assert isinstance(rqc_job["config"]["inputs"]["input_fq1"], list)
+    assert isinstance(rqc_job["config"]["inputs"]["input_fq2"], list)
+
+    # Simulate RQC completing; loading now (not before) ensures cycle 1 exercised input_fq1/fq2.
+    # Cycle 2: scheduler sees Filtered Sequencing Reads and creates the Assembly job.
+    load_fixture(test_db, "read_qc_analysis.json", col="workflow_execution_set")
     resp = jm.cycle()
     assemblies = [j for j in resp if j["config"]["activity"]["type"] == "nmdc:MetagenomeAssembly"]
     assert assemblies


### PR DESCRIPTION
Scheduler was creating jobs where the non-interleaved inputs were strings and not an array of strings as the WDL expects. There is an existing test for this, but it only checks inputs to metagenome assembly workflows, not ReadsQC. 
This PR:
- "input_fq1" and "input_fq2" are now arrays in jobs created by scheduler
- Updates test_scheduler_create_job_rec_has_input_files_as_array in test_sched.py so it tests inputs to ReadsQC as well as inputs to metagenome assembly

Note: issue with nmdcda's github configuration so first push appears under mbthonrton-lbl / scanon