### PR TITLE
add error handling for non-existent IDs in get_existing_jobs

### DIFF
--- a/nmdc_automation/api/nmdcapi.py
+++ b/nmdc_automation/api/nmdcapi.py
@@ -16,7 +16,7 @@ from typing import Union, List
 from datetime import datetime, timedelta, timezone
 from nmdc_automation.config import SiteConfig, UserConfig
 import logging
-from tenacity import retry, wait_exponential, stop_after_attempt
+from tenacity import retry, wait_exponential, stop_after_attempt, retry_if_exception
 from requests.exceptions import HTTPError
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -474,7 +474,22 @@ class NmdcRuntimeApi:
             url = orig_url + "&page_token=%s" % (resp["next_page_token"])
         return results
 
-    @retry(wait=wait_exponential(multiplier=4, min=8, max=120), stop=stop_after_attempt(6), reraise=True)
+    # Optimized to not retry on 404 ("Not Found" errors), since retrying won't eventuall
+    # retrieve the data. All other error codes will continue to trigger a 6-attempt exponential 
+    # backoff to handle transient network or server-side issues.
+    @retry(
+        retry=retry_if_exception(
+            lambda e: not (
+                isinstance(e, HTTPError) and 
+                getattr(e, "response", None) is not None and 
+                e.response.status_code == 404
+            )
+        ),
+        # for other error codes, retry
+        wait=wait_exponential(multiplier=4, min=8, max=120),
+        stop=stop_after_attempt(6),
+        reraise=True
+    )
     @refresh_token
     def get_op(self, opid):
         url = "%soperations/%s" % (self._base_url, opid)

--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -13,6 +13,7 @@ from nmdc_automation.workflow_automation.workflow_process import load_workflow_p
 from nmdc_automation.models.workflow import WorkflowConfig, WorkflowProcessNode
 from semver.version import Version
 import sys
+from requests.exceptions import HTTPError
 
 
 _POLL_INTERVAL = 60
@@ -364,10 +365,26 @@ class Scheduler:
             for claim in claims:
                 op_id = claim.get("op_id")
                 if op_id:
-                    op_obj = self.api.get_op(op_id)
-                    if op_obj.get("done") is False:
-                        is_active = True
-                        break # Stop checking claims for this job
+                    try:
+                        op_obj = self.api.get_op(op_id)
+                        if op_obj.get("done") is False:
+                            is_active = True
+                            break # Stop checking claims for this job
+                    except HTTPError as e:
+                        # check if it was specifically a data issue (404)
+                        # and only continue for this use case
+                        status_code = getattr(e.response, 'status_code', None)
+                        if status_code == 404:
+                            logger.warning(f"Data missing (404) for operation ID {op_id}.")
+                            continue
+                        
+                        logger.error(f"API Error {status_code} for {op_id}. Aborting cycle for safety.")
+                        raise 
+
+                    except Exception as e:
+                        logger.error(f"Critical system failure during op check: {e}")
+                        raise
+
             if is_active:
                 existing_jobs.add(act)
                 continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from pytest import fixture
 import requests
 import requests_mock
+from requests.exceptions import HTTPError
 import shutil
 from time import time
 import pandas as pd
@@ -268,7 +269,18 @@ def configured_api_mock(session_monkeypatch, test_db, test_data_dir):
         # Search the operations collection for the matching ID
         op = test_db.operations.find_one({"id": op_id})
         
-        return op if op else {}
+        if op:
+            return op
+        
+        # else data is missing so return a 404 error like the api:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_resp.reason = "Not Found"
+        mock_resp.url = f"https://api-dev.microbiomedata.org/operations/{op_id}"
+        
+        # This error will bubble up through Tenacity and crash the test 
+        # unless a try/except is added to the Scheduler code.
+        raise HTTPError(f"404 Client Error: Not Found for url: {mock_resp.url}", response=mock_resp)
 
     mock_api.get_op.side_effect = mock_get_op_side_effect
 

--- a/tests/fixtures/nmdc_db/data_generation_5.json
+++ b/tests/fixtures/nmdc_db/data_generation_5.json
@@ -1,0 +1,70 @@
+[{
+  "analyte_category": "metagenome",
+  "associated_studies": [
+    "nmdc:sty-11-34xj1150"
+  ],
+  "has_input": [
+    "nmdc:procsm-15-z0hess48"
+  ],
+  "has_output": [
+    "nmdc:dobj-15-ey05e010",
+    "nmdc:dobj-15-fw2xxn07"
+  ],
+  "id": "nmdc:dgns-15-bvywdf28",
+  "instrument_used": [
+    "nmdc:inst-14-xz5tb342"
+  ],
+  "name": "Terrestrial soil microbial communities - CPER_047-M-20210628-COMP-DNA1",
+  "ncbi_project_name": "PRJNA406974",
+  "processing_institution": "Battelle",
+  "type": "nmdc:NucleotideSequencing"
+},
+{
+  "analyte_category": "metagenome",
+  "associated_studies": [
+    "nmdc:sty-11-34xj1150"
+  ],
+  "has_input": [
+    "nmdc:procsm-15-j2k9jz51"
+  ],
+  "has_output": [
+    "nmdc:dobj-15-s0y8p788",
+    "nmdc:dobj-15-3eq34624"
+  ],
+  "id": "nmdc:dgns-15-t2fsrq37",
+  "instrument_used": [
+    "nmdc:inst-14-xz5tb342"
+  ],
+  "name": "Terrestrial soil microbial communities - TALL_007-M-20210603-COMP-DNA1",
+  "ncbi_project_name": "PRJNA406974",
+  "processing_institution": "Battelle",
+  "type": "nmdc:NucleotideSequencing"
+},
+{
+  "has_input": [
+    "nmdc:procsm-11-k9htz473"
+  ],
+  "has_output": [
+    "nmdc:dobj-11-8ecwcj38",
+    "nmdc:dobj-11-stgwcv16"
+  ],
+  "id": "nmdc:omprc-11-4pjzvb35",
+  "name": "Terrestrial soil microbial communities - YELL_052-O-20190820-COMP-DNA1",
+  "ncbi_project_name": "PRJNA406974",
+  "processing_institution": "Battelle",
+  "type": "nmdc:NucleotideSequencing",
+  "gold_sequencing_project_identifiers": [
+    "gold:Gp0766093"
+  ],
+  "analyte_category": "metagenome",
+  "associated_studies": [
+    "nmdc:sty-11-34xj1150"
+  ],
+  "instrument_used": [
+    "nmdc:inst-14-xz5tb342"
+  ],
+  "provenance_metadata": {
+    "type": "nmdc:ProvenanceMetadata",
+    "mod_date": "2026-04-21T03:51:48Z"
+  }
+}]

--- a/tests/fixtures/nmdc_db/data_objects_5.json
+++ b/tests/fixtures/nmdc_db/data_objects_5.json
@@ -1,0 +1,60 @@
+[{
+  "data_object_type": "Metagenome Raw Read 2",
+  "description": "sequencing results for BMI_HY5W2BGXG_Plate19S_31WellG3_R2",
+  "id": "nmdc:dobj-11-8ecwcj38",
+  "md5_checksum": "818d0bc4bff45f46c9d3630ffbb80cd4",
+  "name": "BMI_HY5W2BGXG_Plate19S_31WellG3_R2.fastq.gz",
+  "type": "nmdc:DataObject",
+  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2020/BMI_HY5W2BGXG_mms_R2/BMI_HY5W2BGXG_Plate19S_31WellG3_R2.fastq.gz",
+  "data_category": "instrument_data"
+},
+{
+  "data_object_type": "Metagenome Raw Read 1",
+  "description": "sequencing results for BMI_HY5W2BGXG_Plate19S_31WellG3_R1",
+  "id": "nmdc:dobj-11-stgwcv16",
+  "md5_checksum": "fd75ef2c0fdabcb7144053ef091fe41b",
+  "name": "BMI_HY5W2BGXG_Plate19S_31WellG3_R1.fastq.gz",
+  "type": "nmdc:DataObject",
+  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2020/BMI_HY5W2BGXG_mms_R1/BMI_HY5W2BGXG_Plate19S_31WellG3_R1.fastq.gz",
+  "data_category": "instrument_data"
+},
+{
+  "data_category": "instrument_data",
+  "data_object_type": "Metagenome Raw Read 2",
+  "description": "sequencing results for BMI_21S_24_2195_mms_H2WYNBGXT_R2",
+  "id": "nmdc:dobj-15-3eq34624",
+  "md5_checksum": "d3f0ef6b28ed64a421a34ef3635f8eb5",
+  "name": "BMI_21S_24_2195_mms_H2WYNBGXT_R2.fastq.gz",
+  "type": "nmdc:DataObject",
+  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/H2WYNBGXT_R2/BMI_21S_24_2195_mms_H2WYNBGXT_R2.fastq.gz"
+},
+{
+  "data_category": "instrument_data",
+  "data_object_type": "Metagenome Raw Read 1",
+  "description": "sequencing results for BMI_21S_23_2077_mms_HN27GBGXN_R1",
+  "id": "nmdc:dobj-15-ey05e010",
+  "md5_checksum": "e31aa5fbbe6e2b9fc1383779fa44be70",
+  "name": "BMI_21S_23_2077_mms_HN27GBGXN_R1.fastq.gz",
+  "type": "nmdc:DataObject",
+  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HN27GBGXN_R1/BMI_21S_23_2077_mms_HN27GBGXN_R1.fastq.gz"
+},
+{
+  "data_category": "instrument_data",
+  "data_object_type": "Metagenome Raw Read 2",
+  "description": "sequencing results for BMI_21S_23_2077_mms_HN27GBGXN_R2",
+  "id": "nmdc:dobj-15-fw2xxn07",
+  "md5_checksum": "c2966c77d5630f705b0249a98ab1144d",
+  "name": "BMI_21S_23_2077_mms_HN27GBGXN_R2.fastq.gz",
+  "type": "nmdc:DataObject",
+  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HN27GBGXN_R2/BMI_21S_23_2077_mms_HN27GBGXN_R2.fastq.gz"
+},
+{
+  "data_category": "instrument_data",
+  "data_object_type": "Metagenome Raw Read 1",
+  "description": "sequencing results for BMI_21S_24_2195_mms_H2WYNBGXT_R1",
+  "id": "nmdc:dobj-15-s0y8p788",
+  "md5_checksum": "ed239b98ca836f4105638de895aa534c",
+  "name": "BMI_21S_24_2195_mms_H2WYNBGXT_R1.fastq.gz",
+  "type": "nmdc:DataObject",
+  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/H2WYNBGXT_R1/BMI_21S_24_2195_mms_H2WYNBGXT_R1.fastq.gz"
+}]

--- a/tests/fixtures/nmdc_db/jobs_5.json
+++ b/tests/fixtures/nmdc_db/jobs_5.json
@@ -1,0 +1,352 @@
+[{
+  "workflow": {
+    "id": "Reads QC Interleave: v1.0.20"
+  },
+  "id": "nmdc:sys0hdgk2w95",
+  "created_at": {
+    "$date": "2026-04-17T21:14:31.724Z"
+  },
+  "config": {
+    "git_repo": "https://github.com/microbiomedata/ReadsQC",
+    "release": "v1.0.20",
+    "wdl": "interleave_rqcfilter.wdl",
+    "activity_id": "nmdc:wfrqc-11-avb69r07.1",
+    "activity_set": "workflow_execution_set",
+    "was_informed_by": [
+      "nmdc:dgns-15-bvywdf28"
+    ],
+    "trigger_activity": "nmdc:dgns-15-bvywdf28",
+    "iteration": 1,
+    "input_prefix": "nmdc_rqcfilter",
+    "inputs": {
+      "proj": "nmdc:wfrqc-11-avb69r07.1",
+      "input_fastq1": [
+        "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HN27GBGXN_R1/BMI_21S_23_2077_mms_HN27GBGXN_R1.fastq.gz"
+      ],
+      "input_fastq2": [
+        "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HN27GBGXN_R2/BMI_21S_23_2077_mms_HN27GBGXN_R2.fastq.gz"
+      ]
+    },
+    "input_data_objects": [
+      {
+        "id": "nmdc:dobj-15-ey05e010",
+        "type": "nmdc:DataObject",
+        "name": "BMI_21S_23_2077_mms_HN27GBGXN_R1.fastq.gz",
+        "description": "sequencing results for BMI_21S_23_2077_mms_HN27GBGXN_R1",
+        "data_category": "instrument_data",
+        "data_object_type": "Metagenome Raw Read 1",
+        "md5_checksum": "e31aa5fbbe6e2b9fc1383779fa44be70",
+        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HN27GBGXN_R1/BMI_21S_23_2077_mms_HN27GBGXN_R1.fastq.gz"
+      },
+      {
+        "id": "nmdc:dobj-15-fw2xxn07",
+        "type": "nmdc:DataObject",
+        "name": "BMI_21S_23_2077_mms_HN27GBGXN_R2.fastq.gz",
+        "description": "sequencing results for BMI_21S_23_2077_mms_HN27GBGXN_R2",
+        "data_category": "instrument_data",
+        "data_object_type": "Metagenome Raw Read 2",
+        "md5_checksum": "c2966c77d5630f705b0249a98ab1144d",
+        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HN27GBGXN_R2/BMI_21S_23_2077_mms_HN27GBGXN_R2.fastq.gz"
+      }
+    ],
+    "activity": {
+      "name": "Read QC for {id}",
+      "input_read_bases": "{outputs.stats.input_read_bases}",
+      "input_read_count": "{outputs.stats.input_read_count}",
+      "output_read_bases": "{outputs.stats.output_read_bases}",
+      "output_read_count": "{outputs.stats.output_read_count}",
+      "type": "nmdc:ReadQcAnalysis"
+    },
+    "outputs": [
+      {
+        "output": "filtered_final",
+        "name": "Reads QC result fastq (clean data)",
+        "data_object_type": "Filtered Sequencing Reads",
+        "description": "Reads QC for {id}",
+        "id": "nmdc:dobj-11-rkjjm110"
+      },
+      {
+        "output": "filtered_stats_final",
+        "name": "Reads QC summary statistics",
+        "data_object_type": "QC Statistics",
+        "description": "Reads QC summary for {id}",
+        "id": "nmdc:dobj-11-rdmhyz17"
+      },
+      {
+        "output": "rqc_info",
+        "name": "File containing read filtering information",
+        "data_object_type": "Read Filtering Info File",
+        "description": "Read filtering info for {id}",
+        "id": "nmdc:dobj-11-hqgf5t87"
+      }
+    ]
+  },
+  "claims": [
+    {
+      "op_id": "nmdc:sys0pa082114",
+      "site_id": "NERSC"
+    }
+  ]
+},
+{
+  "workflow": {
+    "id": "Reads QC Interleave: v1.0.20"
+  },
+  "id": "nmdc:sys02e7gcc45",
+  "created_at": {
+    "$date": "2026-04-17T21:15:52.818Z"
+  },
+  "config": {
+    "git_repo": "https://github.com/microbiomedata/ReadsQC",
+    "release": "v1.0.20",
+    "wdl": "interleave_rqcfilter.wdl",
+    "activity_id": "nmdc:wfrqc-11-4txzht17.1",
+    "activity_set": "workflow_execution_set",
+    "was_informed_by": [
+      "nmdc:dgns-15-t2fsrq37"
+    ],
+    "trigger_activity": "nmdc:dgns-15-t2fsrq37",
+    "iteration": 1,
+    "input_prefix": "nmdc_rqcfilter",
+    "inputs": {
+      "proj": "nmdc:wfrqc-11-4txzht17.1",
+      "input_fastq1": [
+        "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/H2WYNBGXT_R1/BMI_21S_24_2195_mms_H2WYNBGXT_R1.fastq.gz"
+      ],
+      "input_fastq2": [
+        "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/H2WYNBGXT_R2/BMI_21S_24_2195_mms_H2WYNBGXT_R2.fastq.gz"
+      ]
+    },
+    "input_data_objects": [
+      {
+        "id": "nmdc:dobj-15-s0y8p788",
+        "type": "nmdc:DataObject",
+        "name": "BMI_21S_24_2195_mms_H2WYNBGXT_R1.fastq.gz",
+        "description": "sequencing results for BMI_21S_24_2195_mms_H2WYNBGXT_R1",
+        "data_category": "instrument_data",
+        "data_object_type": "Metagenome Raw Read 1",
+        "md5_checksum": "ed239b98ca836f4105638de895aa534c",
+        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/H2WYNBGXT_R1/BMI_21S_24_2195_mms_H2WYNBGXT_R1.fastq.gz"
+      },
+      {
+        "id": "nmdc:dobj-15-3eq34624",
+        "type": "nmdc:DataObject",
+        "name": "BMI_21S_24_2195_mms_H2WYNBGXT_R2.fastq.gz",
+        "description": "sequencing results for BMI_21S_24_2195_mms_H2WYNBGXT_R2",
+        "data_category": "instrument_data",
+        "data_object_type": "Metagenome Raw Read 2",
+        "md5_checksum": "d3f0ef6b28ed64a421a34ef3635f8eb5",
+        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/H2WYNBGXT_R2/BMI_21S_24_2195_mms_H2WYNBGXT_R2.fastq.gz"
+      }
+    ],
+    "activity": {
+      "name": "Read QC for {id}",
+      "input_read_bases": "{outputs.stats.input_read_bases}",
+      "input_read_count": "{outputs.stats.input_read_count}",
+      "output_read_bases": "{outputs.stats.output_read_bases}",
+      "output_read_count": "{outputs.stats.output_read_count}",
+      "type": "nmdc:ReadQcAnalysis"
+    },
+    "outputs": [
+      {
+        "output": "filtered_final",
+        "name": "Reads QC result fastq (clean data)",
+        "data_object_type": "Filtered Sequencing Reads",
+        "description": "Reads QC for {id}",
+        "id": "nmdc:dobj-11-jmssny84"
+      },
+      {
+        "output": "filtered_stats_final",
+        "name": "Reads QC summary statistics",
+        "data_object_type": "QC Statistics",
+        "description": "Reads QC summary for {id}",
+        "id": "nmdc:dobj-11-a93zbh43"
+      },
+      {
+        "output": "rqc_info",
+        "name": "File containing read filtering information",
+        "data_object_type": "Read Filtering Info File",
+        "description": "Read filtering info for {id}",
+        "id": "nmdc:dobj-11-c2h00j28"
+      }
+    ]
+  },
+  "claims": [
+    {
+      "op_id": "nmdc:sys0jsvq4p45",
+      "site_id": "NERSC"
+    }
+  ]
+},
+{
+  "workflow": {
+    "id": "Reads QC Interleave: v1.0.8"
+  },
+  "id": "nmdc:004fea18-480c-11ee-9c24-ee3fb66564cb",
+  "created_at": {
+    "$date": "2023-08-31T14:38:07.000Z"
+  },
+  "config": {
+    "git_repo": "https://github.com/microbiomedata/ReadsQC",
+    "release": "v1.0.8",
+    "wdl": "interleave_rqcfilter.wdl",
+    "activity_id": "nmdc:wfrqc-11-0nh22219.1",
+    "activity_set": "read_qc_analysis_activity_set",
+    "was_informed_by": [
+      "nmdc:omprc-11-4pjzvb35"
+    ],
+    "trigger_activity": "nmdc:omprc-11-4pjzvb35",
+    "iteration": 1,
+    "input_prefix": "nmdc_rqcfilter",
+    "inputs": {
+      "proj": "nmdc:wfrqc-11-0nh22219.1",
+      "input_fastq1": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2020/BMI_HY5W2BGXG_mms_R1/BMI_HY5W2BGXG_Plate19S_31WellG3_R1.fastq.gz",
+      "input_fastq2": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2020/BMI_HY5W2BGXG_mms_R2/BMI_HY5W2BGXG_Plate19S_31WellG3_R2.fastq.gz"
+    },
+    "input_data_objects": [
+      {
+        "id": "nmdc:dobj-11-stgwcv16",
+        "name": "BMI_HY5W2BGXG_Plate19S_31WellG3_R1.fastq.gz",
+        "description": "sequencing results for BMI_HY5W2BGXG_Plate19S_31WellG3_R1",
+        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2020/BMI_HY5W2BGXG_mms_R1/BMI_HY5W2BGXG_Plate19S_31WellG3_R1.fastq.gz",
+        "md5_checksum": "fd75ef2c0fdabcb7144053ef091fe41b",
+        "file_size_bytes": null,
+        "data_object_type": "Metagenome Raw Read 1"
+      },
+      {
+        "id": "nmdc:dobj-11-8ecwcj38",
+        "name": "BMI_HY5W2BGXG_Plate19S_31WellG3_R2.fastq.gz",
+        "description": "sequencing results for BMI_HY5W2BGXG_Plate19S_31WellG3_R2",
+        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2020/BMI_HY5W2BGXG_mms_R2/BMI_HY5W2BGXG_Plate19S_31WellG3_R2.fastq.gz",
+        "md5_checksum": "818d0bc4bff45f46c9d3630ffbb80cd4",
+        "file_size_bytes": null,
+        "data_object_type": "Metagenome Raw Read 2"
+      }
+    ],
+    "activity": {
+      "name": "Read QC Activity for {id}",
+      "input_read_bases": "{outputs.stats.input_read_bases}",
+      "input_read_count": "{outputs.stats.input_read_count}",
+      "output_read_bases": "{outputs.stats.output_read_bases}",
+      "output_read_count": "{outputs.stats.output_read_count}",
+      "type": "nmdc:ReadQcAnalysisActivity"
+    },
+    "outputs": [
+      {
+        "output": "filtered_final",
+        "name": "Reads QC result fastq (clean data)",
+        "suffix": "_filtered.fastq.gz",
+        "data_object_type": "Filtered Sequencing Reads",
+        "description": "Reads QC for {id}",
+        "id": "nmdc:dobj-11-3gs7a830"
+      },
+      {
+        "output": "filtered_stats_final",
+        "name": "Reads QC summary statistics",
+        "suffix": "_filterStats.txt",
+        "data_object_type": "QC Statistics",
+        "description": "Reads QC summary for {id}",
+        "id": "nmdc:dobj-11-r6qzr840"
+      },
+      {
+        "output": "rqc_info",
+        "name": "File containing read filtering information",
+        "suffix": "_readsQC.info",
+        "data_object_type": "Read Filtering Info File",
+        "description": "Read filtering info for {id}",
+        "id": "nmdc:dobj-11-r3vd7b96"
+      }
+    ]
+  },
+  "claims": [
+    {
+      "op_id": "nmdc:sys0s2fgsk47",
+      "site_id": "NERSC"
+    }
+  ]
+},
+{
+  "workflow": {
+    "id": "Reads QC Interleave: v1.0.18"
+  },
+  "id": "nmdc:50332256-2213-11f0-9ac9-bebac50d2d4e",
+  "created_at": {
+    "$date": "2025-04-25T20:24:39.000Z"
+  },
+  "config": {
+    "git_repo": "https://github.com/microbiomedata/ReadsQC",
+    "release": "v1.0.18",
+    "wdl": "interleave_rqcfilter.wdl",
+    "activity_id": "nmdc:wfrqc-11-kk5jqr85.1",
+    "activity_set": "workflow_execution_set",
+    "was_informed_by": [
+      "nmdc:omprc-11-4pjzvb35"
+    ],
+    "trigger_activity": "nmdc:omprc-11-4pjzvb35",
+    "iteration": 1,
+    "input_prefix": "nmdc_rqcfilter",
+    "inputs": {
+      "proj": "nmdc:wfrqc-11-kk5jqr85.1",
+      "input_fastq1": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2020/BMI_HY5W2BGXG_mms_R1/BMI_HY5W2BGXG_Plate19S_31WellG3_R1.fastq.gz",
+      "input_fastq2": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2020/BMI_HY5W2BGXG_mms_R2/BMI_HY5W2BGXG_Plate19S_31WellG3_R2.fastq.gz"
+    },
+    "input_data_objects": [
+      {
+        "id": "nmdc:dobj-11-stgwcv16",
+        "type": "nmdc:DataObject",
+        "name": "BMI_HY5W2BGXG_Plate19S_31WellG3_R1.fastq.gz",
+        "description": "sequencing results for BMI_HY5W2BGXG_Plate19S_31WellG3_R1",
+        "data_object_type": "Metagenome Raw Read 1",
+        "md5_checksum": "fd75ef2c0fdabcb7144053ef091fe41b",
+        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2020/BMI_HY5W2BGXG_mms_R1/BMI_HY5W2BGXG_Plate19S_31WellG3_R1.fastq.gz"
+      },
+      {
+        "id": "nmdc:dobj-11-8ecwcj38",
+        "type": "nmdc:DataObject",
+        "name": "BMI_HY5W2BGXG_Plate19S_31WellG3_R2.fastq.gz",
+        "description": "sequencing results for BMI_HY5W2BGXG_Plate19S_31WellG3_R2",
+        "data_object_type": "Metagenome Raw Read 2",
+        "md5_checksum": "818d0bc4bff45f46c9d3630ffbb80cd4",
+        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2020/BMI_HY5W2BGXG_mms_R2/BMI_HY5W2BGXG_Plate19S_31WellG3_R2.fastq.gz"
+      }
+    ],
+    "activity": {
+      "name": "Read QC for {id}",
+      "input_read_bases": "{outputs.stats.input_read_bases}",
+      "input_read_count": "{outputs.stats.input_read_count}",
+      "output_read_bases": "{outputs.stats.output_read_bases}",
+      "output_read_count": "{outputs.stats.output_read_count}",
+      "type": "nmdc:ReadQcAnalysis"
+    },
+    "outputs": [
+      {
+        "output": "filtered_final",
+        "name": "Reads QC result fastq (clean data)",
+        "data_object_type": "Filtered Sequencing Reads",
+        "description": "Reads QC for {id}",
+        "id": "nmdc:dobj-11-hyzq0f85"
+      },
+      {
+        "output": "filtered_stats_final",
+        "name": "Reads QC summary statistics",
+        "data_object_type": "QC Statistics",
+        "description": "Reads QC summary for {id}",
+        "id": "nmdc:dobj-11-e2v4st30"
+      },
+      {
+        "output": "rqc_info",
+        "name": "File containing read filtering information",
+        "data_object_type": "Read Filtering Info File",
+        "description": "Read filtering info for {id}",
+        "id": "nmdc:dobj-11-rs7y8847"
+      }
+    ]
+  },
+  "claims": [
+    {
+      "op_id": "nmdc:sys05jhf4y49",
+      "site_id": "NERSC"
+    }
+  ]
+}
+]

--- a/tests/fixtures/nmdc_db/operations_5.json
+++ b/tests/fixtures/nmdc_db/operations_5.json
@@ -1,0 +1,324 @@
+[{
+  "id": "nmdc:sys0pa082114",
+  "done": false,
+  "expire_time": {
+    "$date": "2026-05-17T21:57:35.594Z"
+  },
+  "result": null,
+  "metadata": {
+    "model": "nmdc_runtime.api.models.job.JobOperationMetadata",
+    "cancelled": null,
+    "job": {
+      "workflow": {
+        "name": null,
+        "description": null,
+        "capability_ids": null,
+        "id": "Reads QC Interleave: v1.0.20",
+        "created_at": null
+      },
+      "name": null,
+      "description": null,
+      "id": "nmdc:sys0hdgk2w95",
+      "created_at": null,
+      "config": {
+        "git_repo": "https://github.com/microbiomedata/ReadsQC",
+        "release": "v1.0.20",
+        "wdl": "interleave_rqcfilter.wdl",
+        "activity_id": "nmdc:wfrqc-11-avb69r07.1",
+        "activity_set": "workflow_execution_set",
+        "was_informed_by": [
+          "nmdc:dgns-15-bvywdf28"
+        ],
+        "trigger_activity": "nmdc:dgns-15-bvywdf28",
+        "iteration": 1,
+        "input_prefix": "nmdc_rqcfilter",
+        "inputs": {
+          "proj": "nmdc:wfrqc-11-avb69r07.1",
+          "input_fastq1": [
+            "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HN27GBGXN_R1/BMI_21S_23_2077_mms_HN27GBGXN_R1.fastq.gz"
+          ],
+          "input_fastq2": [
+            "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HN27GBGXN_R2/BMI_21S_23_2077_mms_HN27GBGXN_R2.fastq.gz"
+          ]
+        },
+        "input_data_objects": [
+          {
+            "id": "nmdc:dobj-15-ey05e010",
+            "type": "nmdc:DataObject",
+            "name": "BMI_21S_23_2077_mms_HN27GBGXN_R1.fastq.gz",
+            "description": "sequencing results for BMI_21S_23_2077_mms_HN27GBGXN_R1",
+            "data_category": "instrument_data",
+            "data_object_type": "Metagenome Raw Read 1",
+            "md5_checksum": "e31aa5fbbe6e2b9fc1383779fa44be70",
+            "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HN27GBGXN_R1/BMI_21S_23_2077_mms_HN27GBGXN_R1.fastq.gz"
+          },
+          {
+            "id": "nmdc:dobj-15-fw2xxn07",
+            "type": "nmdc:DataObject",
+            "name": "BMI_21S_23_2077_mms_HN27GBGXN_R2.fastq.gz",
+            "description": "sequencing results for BMI_21S_23_2077_mms_HN27GBGXN_R2",
+            "data_category": "instrument_data",
+            "data_object_type": "Metagenome Raw Read 2",
+            "md5_checksum": "c2966c77d5630f705b0249a98ab1144d",
+            "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HN27GBGXN_R2/BMI_21S_23_2077_mms_HN27GBGXN_R2.fastq.gz"
+          }
+        ],
+        "activity": {
+          "name": "Read QC for {id}",
+          "input_read_bases": "{outputs.stats.input_read_bases}",
+          "input_read_count": "{outputs.stats.input_read_count}",
+          "output_read_bases": "{outputs.stats.output_read_bases}",
+          "output_read_count": "{outputs.stats.output_read_count}",
+          "type": "nmdc:ReadQcAnalysis"
+        },
+        "outputs": [
+          {
+            "output": "filtered_final",
+            "name": "Reads QC result fastq (clean data)",
+            "data_object_type": "Filtered Sequencing Reads",
+            "description": "Reads QC for {id}",
+            "id": "nmdc:dobj-11-rkjjm110"
+          },
+          {
+            "output": "filtered_stats_final",
+            "name": "Reads QC summary statistics",
+            "data_object_type": "QC Statistics",
+            "description": "Reads QC summary for {id}",
+            "id": "nmdc:dobj-11-rdmhyz17"
+          },
+          {
+            "output": "rqc_info",
+            "name": "File containing read filtering information",
+            "data_object_type": "Read Filtering Info File",
+            "description": "Read filtering info for {id}",
+            "id": "nmdc:dobj-11-hqgf5t87"
+          }
+        ]
+      },
+      "claims": []
+    },
+    "site_id": "NERSC"
+  }
+},
+{
+  "id": "nmdc:sys0jsvq4p45",
+  "done": false,
+  "expire_time": {
+    "$date": "2026-05-17T21:36:01.936Z"
+  },
+  "result": null,
+  "metadata": {
+    "model": "nmdc_runtime.api.models.job.JobOperationMetadata",
+    "cancelled": null,
+    "job": {
+      "workflow": {
+        "name": null,
+        "description": null,
+        "capability_ids": null,
+        "id": "Reads QC Interleave: v1.0.20",
+        "created_at": null
+      },
+      "name": null,
+      "description": null,
+      "id": "nmdc:sys02e7gcc45",
+      "created_at": null,
+      "config": {
+        "git_repo": "https://github.com/microbiomedata/ReadsQC",
+        "release": "v1.0.20",
+        "wdl": "interleave_rqcfilter.wdl",
+        "activity_id": "nmdc:wfrqc-11-4txzht17.1",
+        "activity_set": "workflow_execution_set",
+        "was_informed_by": [
+          "nmdc:dgns-15-t2fsrq37"
+        ],
+        "trigger_activity": "nmdc:dgns-15-t2fsrq37",
+        "iteration": 1,
+        "input_prefix": "nmdc_rqcfilter",
+        "inputs": {
+          "proj": "nmdc:wfrqc-11-4txzht17.1",
+          "input_fastq1": [
+            "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/H2WYNBGXT_R1/BMI_21S_24_2195_mms_H2WYNBGXT_R1.fastq.gz"
+          ],
+          "input_fastq2": [
+            "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/H2WYNBGXT_R2/BMI_21S_24_2195_mms_H2WYNBGXT_R2.fastq.gz"
+          ]
+        },
+        "input_data_objects": [
+          {
+            "id": "nmdc:dobj-15-s0y8p788",
+            "type": "nmdc:DataObject",
+            "name": "BMI_21S_24_2195_mms_H2WYNBGXT_R1.fastq.gz",
+            "description": "sequencing results for BMI_21S_24_2195_mms_H2WYNBGXT_R1",
+            "data_category": "instrument_data",
+            "data_object_type": "Metagenome Raw Read 1",
+            "md5_checksum": "ed239b98ca836f4105638de895aa534c",
+            "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/H2WYNBGXT_R1/BMI_21S_24_2195_mms_H2WYNBGXT_R1.fastq.gz"
+          },
+          {
+            "id": "nmdc:dobj-15-3eq34624",
+            "type": "nmdc:DataObject",
+            "name": "BMI_21S_24_2195_mms_H2WYNBGXT_R2.fastq.gz",
+            "description": "sequencing results for BMI_21S_24_2195_mms_H2WYNBGXT_R2",
+            "data_category": "instrument_data",
+            "data_object_type": "Metagenome Raw Read 2",
+            "md5_checksum": "d3f0ef6b28ed64a421a34ef3635f8eb5",
+            "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/H2WYNBGXT_R2/BMI_21S_24_2195_mms_H2WYNBGXT_R2.fastq.gz"
+          }
+        ],
+        "activity": {
+          "name": "Read QC for {id}",
+          "input_read_bases": "{outputs.stats.input_read_bases}",
+          "input_read_count": "{outputs.stats.input_read_count}",
+          "output_read_bases": "{outputs.stats.output_read_bases}",
+          "output_read_count": "{outputs.stats.output_read_count}",
+          "type": "nmdc:ReadQcAnalysis"
+        },
+        "outputs": [
+          {
+            "output": "filtered_final",
+            "name": "Reads QC result fastq (clean data)",
+            "data_object_type": "Filtered Sequencing Reads",
+            "description": "Reads QC for {id}",
+            "id": "nmdc:dobj-11-jmssny84"
+          },
+          {
+            "output": "filtered_stats_final",
+            "name": "Reads QC summary statistics",
+            "data_object_type": "QC Statistics",
+            "description": "Reads QC summary for {id}",
+            "id": "nmdc:dobj-11-a93zbh43"
+          },
+          {
+            "output": "rqc_info",
+            "name": "File containing read filtering information",
+            "data_object_type": "Read Filtering Info File",
+            "description": "Read filtering info for {id}",
+            "id": "nmdc:dobj-11-c2h00j28"
+          }
+        ]
+      },
+      "claims": []
+    },
+    "site_id": "NERSC"
+  }
+},
+{
+  "id": "nmdc:sys05jhf4y49",
+  "done": true,
+  "expire_time": {
+    "$date": "2025-05-29T15:52:23.414Z"
+  },
+  "result": null,
+  "metadata": {
+    "model": "nmdc_runtime.api.models.job.JobOperationMetadata",
+    "cancelled": null,
+    "job": {
+      "workflow": {
+        "name": null,
+        "description": null,
+        "capability_ids": null,
+        "id": "Reads QC Interleave: v1.0.18",
+        "created_at": null
+      },
+      "name": null,
+      "description": null,
+      "id": "nmdc:50332256-2213-11f0-9ac9-bebac50d2d4e",
+      "created_at": null,
+      "config": {
+        "git_repo": "https://github.com/microbiomedata/ReadsQC",
+        "release": "v1.0.18",
+        "wdl": "interleave_rqcfilter.wdl",
+        "activity_id": "nmdc:wfrqc-11-kk5jqr85.1",
+        "activity_set": "workflow_execution_set",
+        "was_informed_by": "nmdc:omprc-11-4pjzvb35",
+        "trigger_activity": "nmdc:omprc-11-4pjzvb35",
+        "iteration": 1,
+        "input_prefix": "nmdc_rqcfilter",
+        "inputs": {
+          "proj": "nmdc:wfrqc-11-kk5jqr85.1",
+          "input_fastq1": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2020/BMI_HY5W2BGXG_mms_R1/BMI_HY5W2BGXG_Plate19S_31WellG3_R1.fastq.gz",
+          "input_fastq2": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2020/BMI_HY5W2BGXG_mms_R2/BMI_HY5W2BGXG_Plate19S_31WellG3_R2.fastq.gz"
+        },
+        "input_data_objects": [
+          {
+            "id": "nmdc:dobj-11-stgwcv16",
+            "type": "nmdc:DataObject",
+            "name": "BMI_HY5W2BGXG_Plate19S_31WellG3_R1.fastq.gz",
+            "description": "sequencing results for BMI_HY5W2BGXG_Plate19S_31WellG3_R1",
+            "data_object_type": "Metagenome Raw Read 1",
+            "md5_checksum": "fd75ef2c0fdabcb7144053ef091fe41b",
+            "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2020/BMI_HY5W2BGXG_mms_R1/BMI_HY5W2BGXG_Plate19S_31WellG3_R1.fastq.gz"
+          },
+          {
+            "id": "nmdc:dobj-11-8ecwcj38",
+            "type": "nmdc:DataObject",
+            "name": "BMI_HY5W2BGXG_Plate19S_31WellG3_R2.fastq.gz",
+            "description": "sequencing results for BMI_HY5W2BGXG_Plate19S_31WellG3_R2",
+            "data_object_type": "Metagenome Raw Read 2",
+            "md5_checksum": "818d0bc4bff45f46c9d3630ffbb80cd4",
+            "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2020/BMI_HY5W2BGXG_mms_R2/BMI_HY5W2BGXG_Plate19S_31WellG3_R2.fastq.gz"
+          }
+        ],
+        "activity": {
+          "name": "Read QC for {id}",
+          "input_read_bases": "{outputs.stats.input_read_bases}",
+          "input_read_count": "{outputs.stats.input_read_count}",
+          "output_read_bases": "{outputs.stats.output_read_bases}",
+          "output_read_count": "{outputs.stats.output_read_count}",
+          "type": "nmdc:ReadQcAnalysis"
+        },
+        "outputs": [
+          {
+            "output": "filtered_final",
+            "name": "Reads QC result fastq (clean data)",
+            "data_object_type": "Filtered Sequencing Reads",
+            "description": "Reads QC for {id}",
+            "id": "nmdc:dobj-11-hyzq0f85"
+          },
+          {
+            "output": "filtered_stats_final",
+            "name": "Reads QC summary statistics",
+            "data_object_type": "QC Statistics",
+            "description": "Reads QC summary for {id}",
+            "id": "nmdc:dobj-11-e2v4st30"
+          },
+          {
+            "output": "rqc_info",
+            "name": "File containing read filtering information",
+            "data_object_type": "Read Filtering Info File",
+            "description": "Read filtering info for {id}",
+            "id": "nmdc:dobj-11-rs7y8847"
+          }
+        ]
+      },
+      "claims": []
+    },
+    "site_id": "NERSC",
+    "extra": {
+      "compute_site_id": "nmdc",
+      "cpu_hours": 358.17,
+      "cromwell_run_id": "8d096fda-8eb2-4d27-9f4e-fb833d1e5e23",
+      "id": 108537,
+      "input_site_id": "nmdc",
+      "json_file": "/tmp/tmp2art0ot0.json",
+      "output_dir": "/pscratch/sd/n/nmdcda/jaws_outputs/nmdcda/108537/8d096fda-8eb2-4d27-9f4e-fb833d1e5e23",
+      "result": "succeeded",
+      "status": "done",
+      "status_detail": "The run is complete.",
+      "submitted": "2025-04-29 08:52:31",
+      "tag": "nmdc:omprc-11-4pjzvb35/nmdc:wfrqc-11-kk5jqr85.1",
+      "team_id": "nmdc",
+      "updated": "2025-04-30 14:16:03",
+      "user_id": "nmdcda",
+      "wdl_file": "/tmp/tmpdgy938dl.wdl",
+      "workflow_name": "nmdc_rqcfilter",
+      "workflow_root": "/pscratch/sd/n/nmjaws/nmdc-prod/cromwell-executions/nmdc_rqcfilter/8d096fda-8eb2-4d27-9f4e-fb833d1e5e23",
+      "outputs": {
+        "nmdc_rqcfilter.filtered_final": "/pscratch/sd/n/nmdcda/jaws_outputs/nmdcda/108537/8d096fda-8eb2-4d27-9f4e-fb833d1e5e23/call-finish_rqc/execution/nmdc_wfrqc-11-kk5jqr85.1_filtered.fastq.gz",
+        "nmdc_rqcfilter.filtered_stats2_final": "/pscratch/sd/n/nmdcda/jaws_outputs/nmdcda/108537/8d096fda-8eb2-4d27-9f4e-fb833d1e5e23/call-finish_rqc/execution/nmdc_wfrqc-11-kk5jqr85.1_filterStats2.txt",
+        "nmdc_rqcfilter.filtered_stats_final": "/pscratch/sd/n/nmdcda/jaws_outputs/nmdcda/108537/8d096fda-8eb2-4d27-9f4e-fb833d1e5e23/call-finish_rqc/execution/nmdc_wfrqc-11-kk5jqr85.1_filterStats.txt",
+        "nmdc_rqcfilter.rqc_info": "/pscratch/sd/n/nmdcda/jaws_outputs/nmdcda/108537/8d096fda-8eb2-4d27-9f4e-fb833d1e5e23/call-make_info_file/execution/nmdc_wfrqc-11-kk5jqr85.1_readsQC.info"
+      }
+    }
+  }
+}]

--- a/tests/fixtures/nmdc_db/workflow_execution_5.json
+++ b/tests/fixtures/nmdc_db/workflow_execution_5.json
@@ -1,0 +1,23 @@
+[{
+  "id": "nmdc:wfrqc-11-avb69r07.1",
+  "type": "nmdc:ReadQcAnalysis",
+  "name": "Read QC for nmdc:wfrqc-11-avb69r07.1",
+  "has_input": [
+    "nmdc:dobj-15-ey05e010",
+    "nmdc:dobj-15-fw2xxn07"
+  ],
+  "has_output": [
+    "nmdc:dobj-11-rkjjm110",
+    "nmdc:dobj-11-rdmhyz17",
+    "nmdc:dobj-11-hqgf5t87"
+  ],
+  "processing_institution": "NMDC",
+  "git_url": "https://github.com/microbiomedata/ReadsQC",
+  "started_at_time": "2026-04-17 14:57:42",
+  "was_informed_by": [
+    "nmdc:dgns-15-bvywdf28"
+  ],
+  "ended_at_time": "2026-04-18 09:08:10",
+  "execution_resource": "NERSC-Perlmutter",
+  "version": "v1.0.20"
+}]

--- a/tests/test_nmdcapi.py
+++ b/tests/test_nmdcapi.py
@@ -4,10 +4,13 @@ import os
 import time
 import re
 import requests
+import pytest
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 from unittest.mock import patch, PropertyMock, Mock
 from tests.fixtures.db_utils import load_fixture, reset_db
+from unittest.mock import MagicMock
+from requests.exceptions import HTTPError
 
 
 #def test_basics(requests_mock, site_config_file, mock_api):
@@ -464,3 +467,74 @@ def test_list_from_collection_recovery_success(mock_sleep, monkeypatch, requests
     
     # check backoff sleep was triggered during the retry
     assert mock_sleep.call_count == 1
+
+
+@patch("time.sleep", return_value=None)
+def test_get_op_tenacity_retry(mock_sleep, site_config_file):
+    """
+    Validates Tenacity retry logic for get_op:
+    1. Confirms 404 (Not Found) errors short-circuit and exit immediately (1 attempt).
+    2. Confirms 500 (Server Error) errors trigger the full retry policy (6 attempts).
+    
+    Note: 'time.sleep' is patched to ensure the test suite runs instantly. 
+    To manually verify the exponential backoff timing, temporarily remove 
+    the @patch decorator and the mock_sleep argument.
+    """
+
+    api = nmdcapi(site_config_file)
+    
+    mock_token_resp = MagicMock()
+    mock_token_resp.status_code = 200
+    mock_token_resp.json.return_value = {
+        "access_token": "fake_token",
+        "expires": {
+            "days": 0,
+            "hours": 1,
+            "minutes": 0,
+            "seconds": 0
+        }
+    }
+
+    # setup mock 404 response
+    mock_404_resp = MagicMock()
+    mock_404_resp.status_code = 404
+    mock_404_resp.ok = False
+    mock_404_resp.raise_for_status.side_effect = HTTPError("Not Found", response=mock_404_resp)
+
+    # setup mock 500 response
+    mock_500_resp = MagicMock()
+    mock_500_resp.status_code = 500
+    mock_500_resp.ok = False
+    mock_500_resp.raise_for_status.side_effect = HTTPError("500 Error", response=mock_500_resp)
+
+    # use the request-based side effect
+    def dynamic_resp(prep_request, **kwargs):
+        # Check the URL inside the PreparedRequest object
+        if "/token" in prep_request.url:
+            return mock_token_resp
+        return current_error
+
+    with patch('requests.Session.send', side_effect=dynamic_resp) as mock_send:
+
+        current_error = mock_404_resp
+        with pytest.raises(HTTPError) as excinfo:
+            api.get_op("nmdc:ghost-id")
+        
+    
+        assert excinfo.value.response.status_code == 404
+        # Expect 2 calls: 1 for token, 1 for the operation
+        assert mock_send.call_count == 2
+    
+        # reset for next api call
+        mock_send.reset_mock()
+        api.token = None 
+
+        # test 500 (Should retry 6 times, as defined in the decorator) 
+        current_error = mock_500_resp
+        with pytest.raises(HTTPError):
+            api.get_op("nmdc:test-id")
+        
+
+        # 1 token call + 6 op attempts = 7
+        assert mock_send.call_count == 7
+        

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -2,7 +2,9 @@ from nmdc_automation.workflow_automation.sched import Scheduler, SchedulerJob, M
 from pytest import mark
 import pytest
 from unittest.mock import patch, MagicMock
+from requests.exceptions import HTTPError
 import copy
+import time
 
 from nmdc_automation.workflow_automation.workflow_process import load_workflow_process_nodes
 from nmdc_automation.workflow_automation.workflows import load_workflow_configs
@@ -959,3 +961,59 @@ def test_scheduler_cycle_minor_upgrade_of_claimed_jobs(test_db, test_client, wor
     # downstream assembly and rbt from wfp node for rqc v1.0.20 
     resp = jm.cycle()
     assert len(resp) == exp_num_jobs_cycle_1
+
+def test_get_existing_jobs_404_error(test_data_dir, test_db, test_client, workflows_config_dir, site_config_file):
+    """
+    Use case for checking a given ID in the allow list does not schedule for a minor upgrade
+    when there are more than one existing jobs returned for a wf activity    
+    Test also handles associated operations ID not found as properly skipped (edge case)
+    """
+    # Populate the set with test ID
+    allowlist = {"nmdc:dgns-15-bvywdf28"}
+    
+
+    reset_db(test_db)
+
+    load_fixture(test_db, "data_objects_5.json", col="data_object_set")
+    load_fixture(test_db, "data_generation_5.json", col="data_generation_set")
+    
+    # Load 3 jobs records with existing jobs that have a patch version 
+    load_fixture(test_db, "jobs_5.json", col="jobs")
+    # Load associated operations records for two of the jobs
+    load_fixture(test_db, "operations_5.json", col="operations")
+    
+
+    # Scheduler will find one job to create
+    exp_num_jobs_initial = 0
+    
+    jm = Scheduler(workflow_yaml=workflows_config_dir / "workflows.yaml",
+                   site_conf=site_config_file, api=test_client)
+    
+    # Dynamically update the config version in memory to v1.0.24 so test stays consistent
+    for wf in jm.workflows:
+        if "Reads QC Interleave" in wf.name:
+            wf.version = "v1.0.24" 
+            break
+    
+    def mock_get_op_side_effect(op_id):
+        """
+        Retrieves an operation from the DB; raises 404 if missing.
+        """
+        # Search the operations collection for the matching ID
+        op = test_db.operations.find_one({"id": op_id})
+        
+        if op:
+            return op
+        
+        # If not found, mimic the production API 404 failure
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_resp.reason = "Not Found"
+        mock_resp.url = f"https://api-dev.microbiomedata.org/operations/{op_id}"
+        
+        raise HTTPError(f"404 Client Error: Not Found for url: {mock_resp.url}", response=mock_resp)
+    
+    with patch.object(jm.api, 'minter', return_value="mocked-id-123"):
+        resp = jm.cycle(allowlist=allowlist)
+        assert len(resp) == exp_num_jobs_initial
+    


### PR DESCRIPTION
Issue: `get_existing_jobs` lacked exception handling for get_op calls, causing the scheduler to crash when encountering a non-existent ID.

Fix: Added try/except around api call, ensured the loop continue if ID is not found, then can assume job is not in a state of running. Updated `get_op` retry decorator for 404 status_code so missing IDs do not add retry delays unnecessarily. New test coverage for this use case and updated tenacity implementation.