### PR TITLE
bug fix for finding latest wfp_node when identical wf versions are found

### DIFF
--- a/nmdc_automation/workflow_automation/workflow_process.py
+++ b/nmdc_automation/workflow_automation/workflow_process.py
@@ -73,10 +73,22 @@ def _get_latest_version(new_wfp_node, current_wfp_node):
         if curr_ver.patch > new_ver.patch:
             return current_wfp_node
     
-    # Else, choke?
+    # If we have matching version, then this could be due to an upgrade of a wf activity in the graph 
+    # upstream of this activity. In this case, we should return the wfp node with the latest iteration
+    # (note: current vs new doesn't imply latest, just what is being currently processed within the list)
+    if new_ver.major == curr_ver.major and new_ver.minor == curr_ver.minor and new_ver.patch == curr_ver.patch:
+        # Extract the iteration suffix 
+        new_iter = int(new_wfp_node.id.split(".")[-1])
+        curr_iter = int(current_wfp_node.id.split(".")[-1])
+        if new_iter > curr_iter:
+            return new_wfp_node
+        if curr_iter > new_iter:
+            return current_wfp_node
 
-    # Note: Is it possible to have two wf types with same version? i.e., wf_id.1 and wf_id.2 both have same version
-    # Assuming no above.
+    # Else, if it doesn't meet any of these criteria, something is awry and needs to be reviewed.
+    # e.g. same iteration for same wf version, could not properly parse version
+
+    
 
 
 @lru_cache

--- a/tests/fixtures/nmdc_db/workflow_execution_5.json
+++ b/tests/fixtures/nmdc_db/workflow_execution_5.json
@@ -1,23 +1,121 @@
-[{
-  "id": "nmdc:wfrqc-11-avb69r07.1",
-  "type": "nmdc:ReadQcAnalysis",
-  "name": "Read QC for nmdc:wfrqc-11-avb69r07.1",
-  "has_input": [
-    "nmdc:dobj-15-ey05e010",
-    "nmdc:dobj-15-fw2xxn07"
-  ],
-  "has_output": [
-    "nmdc:dobj-11-rkjjm110",
-    "nmdc:dobj-11-rdmhyz17",
-    "nmdc:dobj-11-hqgf5t87"
-  ],
-  "processing_institution": "NMDC",
-  "git_url": "https://github.com/microbiomedata/ReadsQC",
-  "started_at_time": "2026-04-17 14:57:42",
-  "was_informed_by": [
-    "nmdc:dgns-15-bvywdf28"
-  ],
-  "ended_at_time": "2026-04-18 09:08:10",
-  "execution_resource": "NERSC-Perlmutter",
-  "version": "v1.0.20"
-}]
+[
+  {
+    "id": "nmdc:wfmgan-11-kxtjhj81.1",
+    "name": "Metagenome Annotation Analysis Activity for nmdc:wfmgan-11-kxtjhj81.1",
+    "started_at_time": "2023-09-14T17:19:51.858955+00:00",
+    "ended_at_time": "2023-09-24T22:39:55.680322+00:00",
+    "was_informed_by": ["nmdc:omprc-11-bm72c549"],
+    "execution_resource": "NERSC-Perlmutter",
+    "processing_institution":"NMDC",
+    "git_url": "https://github.com/microbiomedata/mg_annotation",
+    "has_input": [
+      "nmdc:dobj-11-p0sjke96"
+    ],
+    "has_output": [
+      "nmdc:dobj-11-344kkq42",
+      "nmdc:dobj-11-rbkvr794",
+      "nmdc:dobj-11-rvsntj04",
+      "nmdc:dobj-11-wbb40p45",
+      "nmdc:dobj-11-dfm00404",
+      "nmdc:dobj-11-tg716576",
+      "nmdc:dobj-11-9zmgs435",
+      "nmdc:dobj-11-jn9v9p54",
+      "nmdc:dobj-11-rj83jj22",
+      "nmdc:dobj-11-1v5rdk30",
+      "nmdc:dobj-11-d1pt7n85",
+      "nmdc:dobj-11-g933a882",
+      "nmdc:dobj-11-mge5bt03",
+      "nmdc:dobj-11-1gxt4763",
+      "nmdc:dobj-11-pp16fa65",
+      "nmdc:dobj-11-71z5bn61",
+      "nmdc:dobj-11-h6jwbw44",
+      "nmdc:dobj-11-kena1c21",
+      "nmdc:dobj-11-hc6x9h30",
+      "nmdc:dobj-11-kqgj0c38",
+      "nmdc:dobj-11-2et55360",
+      "nmdc:dobj-11-km6c4m19",
+      "nmdc:dobj-11-avm4he79"
+    ],
+    "type": "nmdc:MetagenomeAnnotation",
+    "version": "v1.0.5",
+    "gold_analysis_project_identifiers": []
+  },
+  {
+    "id": "nmdc:wfmgan-11-kxtjhj81.2",
+    "name": "Metagenome Annotation Analysis Activity for nmdc:wfmgan-11-kxtjhj81.2",
+    "started_at_time": "2024-04-05T13:46:43.984717+00:00",
+    "ended_at_time": "2024-04-07T13:48:16.858419+00:00",
+    "was_informed_by": ["nmdc:omprc-11-bm72c549"],
+    "execution_resource": "NERSC-Perlmutter",
+    "processing_institution":"NMDC",
+    "git_url": "https://github.com/microbiomedata/mg_annotation",
+    "has_input": [
+      "nmdc:dobj-11-p0sjke96"
+    ],
+    "type": "nmdc:MetagenomeAnnotation",
+    "has_output": [
+      "nmdc:dobj-11-v0bwdc78",
+      "nmdc:dobj-11-ba609m63",
+      "nmdc:dobj-11-esycdj46",
+      "nmdc:dobj-11-jv21gq98",
+      "nmdc:dobj-11-vebpr554",
+      "nmdc:dobj-11-6w3hx171",
+      "nmdc:dobj-11-0s57nz70",
+      "nmdc:dobj-11-azrvb898",
+      "nmdc:dobj-11-dxcyna89",
+      "nmdc:dobj-11-rtraka21",
+      "nmdc:dobj-11-6sebq912",
+      "nmdc:dobj-11-ea52qx78",
+      "nmdc:dobj-11-ayw4ew24",
+      "nmdc:dobj-11-h7p1xf17",
+      "nmdc:dobj-11-ksdt8p74",
+      "nmdc:dobj-11-z4ycww26",
+      "nmdc:dobj-11-z03c6q88",
+      "nmdc:dobj-11-d5c2xp82",
+      "nmdc:dobj-11-sj2rr436",
+      "nmdc:dobj-11-nkwqxr50",
+      "nmdc:dobj-11-me573g27",
+      "nmdc:dobj-11-fmb4pa57",
+      "nmdc:dobj-11-3t6r8r94"
+    ],
+    "version": "v1.0.5"
+  },
+  {
+    "id": "nmdc:wfmgas-11-fw6wxd21.1",
+    "name": "Metagenome Assembly Activity for nmdc:wfmgas-11-fw6wxd21.1",
+    "started_at_time": "2023-09-13T21:03:24.603823+00:00",
+    "ended_at_time": "2023-09-13T21:03:24.603826+00:00",
+    "was_informed_by": ["nmdc:omprc-11-bm72c549"],
+    "processing_institution":"JGI",
+    "git_url": "https://github.com/microbiomedata/metaAssembly",
+    "has_input": [
+      "nmdc:dobj-11-v702hw34"
+    ],
+    "has_output": [
+      "nmdc:dobj-11-p0sjke96",
+      "nmdc:dobj-11-60ya7t63",
+      "nmdc:dobj-11-vmcme814",
+      "nmdc:dobj-11-g72bse26"
+    ],
+    "type": "nmdc:MetagenomeAssembly",
+    "version": "v1.0.3"
+  },
+  {
+    "id": "nmdc:wfrqc-11-mqkh9j68.1",
+    "name": "Read QC Activity for nmdc:wfrqc-11-mqkh9j68.1",
+    "started_at_time": "2023-09-13T21:03:24.603751+00:00",
+    "ended_at_time": "2023-09-13T21:03:24.603755+00:00",
+    "was_informed_by": ["nmdc:omprc-11-bm72c549"],
+    "processing_institution":"JGI",
+    "git_url": "https://github.com/microbiomedata/ReadsQC",
+    "has_input": [
+      "nmdc:dobj-11-9494pg86"
+    ],
+    "has_output": [
+      "nmdc:dobj-11-v702hw34",
+      "nmdc:dobj-11-snfv2s16"
+    ],
+    "type": "nmdc:ReadQcAnalysis",
+    "version": "v1.0.8"
+  }
+]

--- a/tests/test_workflow_process.py
+++ b/tests/test_workflow_process.py
@@ -129,6 +129,30 @@ def test_load_workflow_process_nodes_with_obsolete_versions(test_db, test_client
     assert resolved_nodes
 
 
+def test_load_workflow_process_nodes_with_identical_versions(test_db, test_client, workflows_config_dir):
+    """
+    Test loading workflow process nodes for a case where has identical versions of the same workflow.
+    This can happen if rqc wf version was upgraded but downstream activies were not.
+    Example:
+    Run 1 (Legacy):       ReadsQC v1.0.8 (.1) -> other wfs -> Annotation v1.0.5 (.1)
+    Run 2 (Reprocessed):  ReadsQC v1.1.0 (.2) -> other wfs -> Annotation v1.0.5 (.2)
+                                  ^                                      ^
+                          (Version Upgrade)                   (Version Collision)
+    """
+    reset_db(test_db)
+    load_fixture(test_db, "data_objects_2.json", "data_object_set")
+    load_fixture(test_db, "data_generation_3.json", "data_generation_set")
+    load_fixture(test_db, "workflow_execution_5.json", "workflow_execution_set") #modified from workflow_execution_3.json
+
+    workflow_config = load_workflow_configs(workflows_config_dir / "workflows.yaml")
+    
+    workflow_process_nodes, manifest_map = load_workflow_process_nodes(test_client, workflow_config)
+
+    annotation_nodes = [n for n in workflow_process_nodes if n.type == "nmdc:MetagenomeAnnotation"]
+    assert len(annotation_nodes) == 1
+    assert annotation_nodes[0].id == "nmdc:wfmgan-11-kxtjhj81.2"
+
+
 def test_resolve_relationships(test_db, test_client, workflows_config_dir):
     """
     Test that the relationships between workflow process nodes are resolved


### PR DESCRIPTION
The scheduler previously assumed that every unique execution of a workflow on a sample must have a distinct Semantic Version. However, it failed to account for upstream version upgrades. 

The fix modifies `workflow_process.py::_get_latest_version` to implement an iteration-based tie-breaker. When wf versions are identical, the logic now extracts the iteration suffix from the `wfp_node.id` of the two nodes being compared to determine the "latest" node.