### PR TITLE
691 automation testing of semibin2 updates

### DIFF
--- a/nmdc_automation/config/workflows/workflows.yaml
+++ b/nmdc_automation/config/workflows/workflows.yaml
@@ -299,6 +299,8 @@ Workflows:
     Version: v2.0.2
     WDL: mbin_nmdc.wdl
     Collection: workflow_execution_set
+    Filter Input Objects:
+    - Assembly Contigs      
     Predecessors:
     - Metagenome Annotation
     Input_prefix: nmdc_mags
@@ -335,6 +337,7 @@ Workflows:
       data_object_type: CheckM Statistics
       description: CheckM for {id}
       name: CheckM statistics report
+      optional: true
     - output: final_hqmq_bins_zip
       data_object_type: Metagenome HQMQ Bins Compression File
       description: Metagenome HQMQ Bins for {id}
@@ -343,6 +346,7 @@ Workflows:
       data_object_type: GTDBTK Summary JSON
       description: GTDBTK Summary for {id}
       name: GTDBTK summary
+      optional: true
     - output: mags_version
       data_object_type: Metagenome Bins Info File
       description: Metagenome Bins Info File for {id}

--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -145,6 +145,12 @@ class Scheduler:
         # Get all the data objects
         next_act = job.trigger_act
         do_by_type = dict()
+
+        # Extract the filters from the YAML for the current workflow (e.g., MAGs)
+        wf_filters = job.workflow.filter_input_objects or []
+        # Keep track of the source that provided the data for Filter Input Objects
+        type_source_map = dict()
+        
         while next_act:
 
             #
@@ -162,6 +168,17 @@ class Scheduler:
 
             else:
                 for do_type, data_object in next_act.data_objects_by_type.items():
+
+                    if do_type in wf_filters:
+                        current_source = type_source_map.get(do_type)
+                        # If we find this type in a new (higher) activity, wipe the downstream data
+                        if current_source and current_source != next_act.id:
+                            logging.debug(f"Using upstream type: {do_type} from {type_source_map[do_type]} "
+                                          f"from {next_act.id}")
+                            del do_by_type[do_type]
+                        type_source_map[do_type] = next_act.id
+                        
+
                     if do_type in do_by_type:
                         logger.debug(f"Ignoring Duplicate type: {do_type} {data_object.id} {next_act.id}")
                         continue

--- a/nmdc_automation/workflow_automation/wfutils.py
+++ b/nmdc_automation/workflow_automation/wfutils.py
@@ -889,16 +889,19 @@ class WorkflowJob:
             if output_key not in self.job.outputs:
                 logger.warning(f"Output key {output_key} not found in job outputs")
                 continue
-            output_file = Path(self.job.outputs[output_key])
-            logger.info(f"Create Data Object: {output_key} file path: {output_file}")
-            if not output_file.exists():
+            #safely get the path, in case it is None
+            output_path = self.job.outputs.get(output_key)
+            if output_path is None:
                 if output_spec.get("optional"):
                     logger.debug(f"Optional output {output_key} not found in job outputs")
                     continue
                 else:
                     logger.warning(f"Required output {output_key} not found in job outputs")
                     continue
-
+                
+            output_file = Path(self.job.outputs[output_key])
+            logger.info(f"Create Data Object: {output_key} file path: {output_file}")
+            
 
             md5_sum = _md5(output_file)
             file_size_bytes = output_file.stat().st_size

--- a/tests/fixtures/mags_jaws_status_optional.json
+++ b/tests/fixtures/mags_jaws_status_optional.json
@@ -18,12 +18,11 @@
     "workflow_name": "nmdc_mags",
     "workflow_root": "/pscratch/sd/n/nmjaws/nmdc-prod/cromwell-executions/nmdc_mags/bac04338-cc14-4186-9b08-3deb4096e031",
     "outputs": {
-      "nmdc_mags.final_checkm": "test_pscratch/nmdc_mags/nmdc_wfmag-12-fxwdrv82.1_checkm_qa.out",
+      "nmdc_mags.final_checkm": null,
+      "nmdc_mags.final_gtdbtk_json": null,
       "nmdc_mags.final_hqmq_bins_zip": "test_pscratch/nmdc_mags/nmdc_wfmag-12-fxwdrv82.1_hqmq_bin.zip",
-      "nmdc_mags.final_gtdbtk_bac_summary": "test_pscratch/nmdc_mags/nmdc_wfmag-12-fxwdrv82.1_gtdbtk.bac122.summary.tsv",
-      "nmdc_mags.final_gtdbtk_ar_summary": "test_pscratch/nmdc_mags/nmdc_wfmag-12-fxwdrv82.1_gtdbtk.ar122.summary.tsv",
       "nmdc_mags.mags_version": "test_pscratch/nmdc_mags/nmdc_wfmag-12-fxwdrv82.1_bin.info",
-      "nmdc_mags.final_lq_bins_zip": "test_pscratch/nmdc_mags/nmdc_wfmag-12-fxwdrv82.1_lq_bin.zip",
+      "nmdc_mags.final_lq_bins_zip": null,
       "nmdc_mags.heatmap": "test_pscratch/nmdc_mags/nmdc_wfmag-12-fxwdrv82.1_heatmap.pdf",
       "nmdc_mags.barplot": "test_pscratch/nmdc_mags/nmdc_wfmag-12-fxwdrv82.1_barplot.pdf",
       "nmdc_mags.kronaplot": "test_pscratch/nmdc_mags/nmdc_wfmag-12-fxwdrv82.1_kronaplot.html"

--- a/tests/fixtures/mags_workflow_state_optional.json
+++ b/tests/fixtures/mags_workflow_state_optional.json
@@ -1,0 +1,274 @@
+{
+  "workflow": {
+    "id": "MAGs: v2.0.2"
+  },
+  "config": {
+    "git_repo": "https://github.com/microbiomedata/metaMAGs",
+    "release": "v2.0.2",
+    "wdl": "mbin_nmdc.wdl",
+    "activity_id": "nmdc:wfmag-11-nvfqkd03.3",
+    "activity_set": "workflow_execution_set",
+    "was_informed_by": [
+      "nmdc:omprc-11-cegmwy02"
+    ],
+    "trigger_activity": "nmdc:wfmgan-11-6x59p192.2",
+    "iteration": 3,
+    "input_prefix": "nmdc_mags",
+    "inputs": {
+      "proj": "nmdc:wfmag-11-nvfqkd03.3",
+      "contig_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgas-11-jchk0x71.1/nmdc_wfmgas-11-jchk0x71.1_contigs.fna",
+      "sam_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgas-11-jchk0x71.1/nmdc_wfmgas-11-jchk0x71.1_pairedMapped_sorted.sam.gz",
+      "gff_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_functional_annotation.gff",
+      "proteins_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_proteins.faa",
+      "cog_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_cog.gff",
+      "ec_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_ec.tsv",
+      "ko_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_ko.tsv",
+      "pfam_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_pfam.gff",
+      "tigrfam_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_tigrfam.gff",
+      "crispr_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_crt.crisprs",
+      "product_names_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_product_names.tsv",
+      "gene_phylogeny_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_gene_phylogeny.tsv",
+      "lineage_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_scaffold_lineage.tsv",
+      "map_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_contig_names_mapping.tsv",
+      "seqtype": "short_reads"
+    },
+    "input_data_objects": [
+      {
+        "id": "nmdc:dobj-11-v41hsd93",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgas-11-jchk0x71.1_contigs.fna",
+        "description": "Assembly contigs for nmdc:omprc-11-cegmwy02",
+        "data_category": "processed_data",
+        "data_object_type": "Assembly Contigs",
+        "file_size_bytes": {
+          "$numberLong": "3212371899"
+        },
+        "md5_checksum": "feee21c0746f2b5b198bb977a06ac156",
+        "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgas-11-jchk0x71.1/nmdc_wfmgas-11-jchk0x71.1_contigs.fna"
+      },
+      {
+        "id": "nmdc:dobj-11-t4b20t83",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgas-11-jchk0x71.1_pairedMapped_sorted.sam.gz",
+        "description": "Sorted Bam for nmdc:omprc-11-cegmwy02",
+        "data_category": "processed_data",
+        "data_object_type": "Assembly Coverage BAM",
+        "file_size_bytes": {
+          "$numberLong": "27595203745"
+        },
+        "md5_checksum": "b259993b912a0ef0c80fec91b0f90d94",
+        "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgas-11-jchk0x71.1/nmdc_wfmgas-11-jchk0x71.1_pairedMapped_sorted.sam.gz"
+      },
+      {
+        "id": "nmdc:dobj-11-xcgb3s36",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-6x59p192.2_functional_annotation.gff",
+        "description": "Functional Annotation for nmdc:wfmgan-11-6x59p192.2",
+        "data_category": "processed_data",
+        "data_object_type": "Functional Annotation GFF",
+        "file_size_bytes": 1718656456,
+        "md5_checksum": "0602d29d19a44b25f77f34c6e27e2e61",
+        "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_functional_annotation.gff"
+      },
+      {
+        "id": "nmdc:dobj-11-b4cqa613",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-6x59p192.2_proteins.faa",
+        "description": "FASTA Amino Acid File for nmdc:wfmgan-11-6x59p192.2",
+        "data_category": "processed_data",
+        "data_object_type": "Annotation Amino Acid FASTA",
+        "file_size_bytes": 1554283442,
+        "md5_checksum": "739fb530a23c8d60e92acf5fe5476c04",
+        "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_proteins.faa"
+      },
+      {
+        "id": "nmdc:dobj-11-m6dfya31",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-6x59p192.2_cog.gff",
+        "description": "COGs for nmdc:wfmgan-11-6x59p192.2",
+        "data_category": "processed_data",
+        "data_object_type": "Clusters of Orthologous Groups (COG) Annotation GFF",
+        "file_size_bytes": 888181611,
+        "md5_checksum": "aab17532f8a5a24c5f7e404dcad9280c",
+        "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_cog.gff"
+      },
+      {
+        "id": "nmdc:dobj-11-jtp5vv62",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-6x59p192.2_ec.tsv",
+        "description": "EC Annotations for nmdc:wfmgan-11-6x59p192.2",
+        "data_category": "processed_data",
+        "data_object_type": "Annotation Enzyme Commission",
+        "file_size_bytes": 141826750,
+        "md5_checksum": "ade2c28496c61c83e84f7b679c41333f",
+        "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_ec.tsv"
+      },
+      {
+        "id": "nmdc:dobj-11-5ge8cb55",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-6x59p192.2_ko.tsv",
+        "description": "KEGG Orthology for nmdc:wfmgan-11-6x59p192.2",
+        "data_category": "processed_data",
+        "data_object_type": "Annotation KEGG Orthology",
+        "file_size_bytes": 211913679,
+        "md5_checksum": "643105f7f4fd8c8b676bf2526a964cf9",
+        "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_ko.tsv"
+      },
+      {
+        "id": "nmdc:dobj-11-gv1jq555",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-6x59p192.2_pfam.gff",
+        "description": "Pfam Annotation for nmdc:wfmgan-11-6x59p192.2",
+        "data_category": "processed_data",
+        "data_object_type": "Pfam Annotation GFF",
+        "file_size_bytes": 837405131,
+        "md5_checksum": "e4cc21248a62bd331aec0be8146065bc",
+        "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_pfam.gff"
+      },
+      {
+        "id": "nmdc:dobj-11-cpbx8z47",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-6x59p192.2_tigrfam.gff",
+        "description": "TIGRFam for nmdc:wfmgan-11-6x59p192.2",
+        "data_category": "processed_data",
+        "data_object_type": "TIGRFam Annotation GFF",
+        "file_size_bytes": 102760331,
+        "md5_checksum": "3763049accb2dbf4f90c5dee1ee0a4a1",
+        "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_tigrfam.gff"
+      },
+      {
+        "id": "nmdc:dobj-11-a6tdwf10",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-6x59p192.2_crt.crisprs",
+        "description": "Crispr Terms for nmdc:wfmgan-11-6x59p192.2",
+        "data_category": "processed_data",
+        "data_object_type": "Crispr Terms",
+        "file_size_bytes": 453711,
+        "md5_checksum": "8679579f51b92aee605b103e28bd3a6c",
+        "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_crt.crisprs"
+      },
+      {
+        "id": "nmdc:dobj-11-4bxp0a30",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-6x59p192.2_product_names.tsv",
+        "description": "Product names for nmdc:wfmgan-11-6x59p192.2",
+        "data_category": "processed_data",
+        "data_object_type": "Product Names",
+        "file_size_bytes": 525174204,
+        "md5_checksum": "ef27a5eff0449f525cd6413daa481a93",
+        "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_product_names.tsv"
+      },
+      {
+        "id": "nmdc:dobj-11-74z1n534",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-6x59p192.2_gene_phylogeny.tsv",
+        "description": "Gene Phylogeny for nmdc:wfmgan-11-6x59p192.2",
+        "data_category": "processed_data",
+        "data_object_type": "Gene Phylogeny tsv",
+        "file_size_bytes": 957972553,
+        "md5_checksum": "30f1bdf12f691df79d922a82ae5d444f",
+        "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_gene_phylogeny.tsv"
+      },
+      {
+        "id": "nmdc:dobj-11-tjwrkw11",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-6x59p192.2_scaffold_lineage.tsv",
+        "description": "Scaffold Lineage tsv for nmdc:wfmgan-11-6x59p192.2",
+        "data_category": "processed_data",
+        "data_object_type": "Scaffold Lineage tsv",
+        "file_size_bytes": 546083812,
+        "md5_checksum": "acaaa810b9f458c15756afc20c14f9d0",
+        "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_scaffold_lineage.tsv"
+      },
+      {
+        "id": "nmdc:dobj-11-x2eb3v05",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-6x59p192.2_contig_names_mapping.tsv",
+        "description": "Contig mappings file for nmdc:wfmgan-11-6x59p192.2",
+        "data_category": "processed_data",
+        "data_object_type": "Contig Mapping File",
+        "file_size_bytes": 215400483,
+        "md5_checksum": "ce169b9943cb55e154e593ff45bf54ec",
+        "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-cegmwy02/nmdc:wfmgan-11-6x59p192.2/nmdc_wfmgan-11-6x59p192.2_contig_names_mapping.tsv"
+      }
+    ],
+    "activity": {
+      "name": "Metagenome Assembled Genomes Analysis for {id}",
+      "type": "nmdc:MagsAnalysis",
+      "binned_contig_num": "{outputs.final_stats_json.binned_contig_num}",
+      "input_contig_num": "{outputs.final_stats_json.input_contig_num}",
+      "low_depth_contig_num": "{outputs.final_stats_json.low_depth_contig_num}",
+      "mags_list": "{outputs.final_stats_json.mags_list}",
+      "too_short_contig_num": "{outputs.final_stats_json.too_short_contig_num}",
+      "unbinned_contig_num": "{outputs.final_stats_json.unbinned_contig_num}"
+    },
+    "outputs": [
+      {
+        "output": "final_checkm",
+        "data_object_type": "CheckM Statistics",
+        "description": "CheckM for {id}",
+        "name": "CheckM statistics report",
+        "optional": true,
+        "id": "nmdc:dobj-01-abcd4321"
+      },
+      {
+        "output": "final_hqmq_bins_zip",
+        "data_object_type": "Metagenome HQMQ Bins Compression File",
+        "description": "Metagenome HQMQ Bins for {id}",
+        "name": "Metagenome hqmq bin zip archive",
+        "id": "nmdc:dobj-01-abcd4321"
+      },
+      {
+        "output": "final_gtdbtk_json",
+        "data_object_type": "GTDBTK Summary JSON",
+        "description": "GTDBTK Summary for {id}",
+        "name": "GTDBTK summary",
+        "optional": true,
+        "id": "nmdc:dobj-01-abcd4321"
+      },
+      {
+        "output": "mags_version",
+        "data_object_type": "Metagenome Bins Info File",
+        "description": "Metagenome Bins Info File for {id}",
+        "name": "Metagenome Bins Info File",
+        "id": "nmdc:dobj-01-abcd4321"
+      },
+      {
+        "output": "final_lq_bins_zip",
+        "data_object_type": "Metagenome LQ Bins Compression File",
+        "description": "Metagenome LQ Bins for {id}",
+        "name": "Metagenome lq bin zip archive",
+        "id": "nmdc:dobj-01-abcd4321"
+      },
+      {
+        "output": "heatmap",
+        "data_object_type": "Metagenome Bins Heatmap",
+        "description": "Metagenome heatmap for {id}",
+        "name": "Metagenome Heatmap File",
+        "id": "nmdc:dobj-01-abcd4321"
+      },
+      {
+        "output": "barplot",
+        "data_object_type": "Metagenome Bins Barplot",
+        "description": "Metagenome barplot for {id}",
+        "name": "Metagenome Barplot File",
+        "id": "nmdc:dobj-01-abcd4321"
+      },
+      {
+        "output": "kronaplot",
+        "data_object_type": "Metagenome Bins Krona Plot",
+        "description": "Metagenome Bins Krona Plot for {id}",
+        "name": "Metagenome Krona Bins Plot File",
+        "id": "nmdc:dobj-01-abcd4321"
+      }
+    ]
+  },
+  "claims": [],
+  "opid": "nmdc:sys0kz401647",
+  "done": false,
+  "start": "2025-03-20T02:55:39.157169+00:00",
+  "cromwell_jobid": "8f4e1a0b-ca5c-455b-9db6-30957bcf4b4a",
+  "last_status": "succeeded",
+  "nmdc_jobid": "nmdc:c18fb5f8-0536-11f0-9035-be45b851a8f7",
+  "end": "2025-03-20T02:58:38.414Z"
+}

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -1017,3 +1017,53 @@ def test_get_existing_jobs_404_error(test_data_dir, test_db, test_client, workfl
         resp = jm.cycle(allowlist=allowlist)
         assert len(resp) == exp_num_jobs_initial
     
+
+def test_scheduler_mags_priority_selection(test_db, test_client, workflows_config_dir, site_config_file):
+    """
+    Test that the scheduler prioritizes Assembly Contigs from the upstream Assembly 
+    activity even though Metagenome Annotation is the sole trigger (Predecessor).
+    """
+    # 1. Setup the environment
+    reset_db(test_db)
+    # Ensure fixtures contain the parent-child link: Annotation -> was_informed_by -> Assembly
+    load_fixture(test_db, "data_objects_2.json", "data_object_set")
+    load_fixture(test_db, "data_generation_2.json", "data_generation_set")
+    load_fixture(test_db, "workflow_execution_2.json", "workflow_execution_set")
+
+    workflow_config = load_workflow_configs(workflows_config_dir / "workflows.yaml")
+
+    scheduler = Scheduler(workflow_yaml=workflows_config_dir / "workflows.yaml", 
+                          site_conf=site_config_file, 
+                          api=test_client)
+    
+    # 2. Find the MAGs job triggered by Annotation
+    workflow_process_nodes, manifest_map = load_workflow_process_nodes(scheduler.api, workflow_config)
+    
+    new_jobs = []
+    for node in workflow_process_nodes:
+        found_jobs = scheduler.find_new_jobs(node, manifest_map, new_jobs)
+        new_jobs.extend(found_jobs)
+    
+    mags_job = next((j for j in new_jobs if j.workflow.type == "nmdc:MagsAnalysis"), None)
+    assert mags_job, "MAGs job should be created with Annotation as the trigger"
+    assert mags_job.trigger_act.type == "nmdc:MetagenomeAnnotation"
+
+    # create_job_rec creates the inputs for the watcher to populate the inputs.json
+    job_req = scheduler.create_job_rec(mags_job, manifest_map)
+    
+    # retrieve the Data Object selection
+    input_data_objects = job_req["config"]["input_data_objects"]
+    selected_ids = [dobj["id"] for dobj in input_data_objects]
+    
+    # expected DO IDs from fixtures
+    assembly_raw_id = "nmdc:dobj-11-v41hsd93" 
+    annotation_renamed_id = "nmdc:dobj-11-tr910y56"
+
+    # contigs ID should be from assembly wf
+    assert assembly_raw_id in selected_ids
+    assert annotation_renamed_id not in selected_ids
+
+    
+    # since only Assembly has a BAM, it should be picked up even if not in filters
+    bam_id = "nmdc:dobj-11-t4b20t83" # Assuming this is the BAM ID in your fixture
+    assert bam_id in selected_ids

--- a/tests/test_watch_nmdc.py
+++ b/tests/test_watch_nmdc.py
@@ -382,6 +382,45 @@ def test_job_manager_process_successful_job(site_config, initial_state_file_1_fa
         jm.job_cache = []
 
 
+def test_job_manager_process_successful_job_optional_output(site_config, initial_state_file_1_failure, fixtures_dir, job_metadata_factory, mock_jaws_api):
+    '''
+    This test makes sure optional MAGs output that are set to optional will properly skip when making
+    the data object. It also tests that required data objects that are missing will skip but warn as expected.
+    The fixture mags_workflow_state_optional.json stores the state of v2.0.2 MAGs where outputs 
+    final_checkm and final_gtdbtk_json have "optional: true", such as the scheduler would
+    read the workflows config and write the outputs specs to the job record for the watcher to read 
+    and process. This also tests that a missing output skips without incident, even if it is required (final_lq_bins_zip).
+    The mags_jaws_status_optional.json is the fixture that represented the successful wf output.
+    '''
+
+
+    modified_job_metadata = job_metadata_factory(fixtures_dir / "mags_jaws_status_optional.json")
+    assert modified_job_metadata is not None
+
+    
+    with patch('nmdc_automation.workflow_automation.wfutils.JawsRunner.get_job_metadata') as mock_get_metadata:
+        mock_get_metadata.return_value = modified_job_metadata
+
+        # Arrange
+        fh = FileHandler(site_config, initial_state_file_1_failure)
+        jm = JobManager(site_config, fh)
+        new_job_state = json.load(open(fixtures_dir / "mags_workflow_state_optional.json"))
+        assert new_job_state
+        new_job = WorkflowJob(site_config, new_job_state, jaws_api=mock_jaws_api)
+        jm.job_cache.append(new_job)
+        # Act
+        db = jm.process_successful_job(new_job)
+        
+        # Assert
+        assert db
+        assert isinstance(db, Database)
+
+        assert new_job.done
+        assert new_job.job_status.lower() == "succeeded"
+        # cleanup
+        jm.job_cache = []
+
+
 def test_job_manager_get_finished_jobs_1_failure(site_config, initial_state_file_1_failure, fixtures_dir):
     # Arrange
     with requests_mock.Mocker() as mocker:


### PR DESCRIPTION
FIrst pass of automation test shook out some bugs. This PR fixes output processing bugs and improve upstream data object selection

- Updated workflows.yaml: Added 'optional' flag to MAGs outputs `final_checkm` and `GTDBTK summary`; Added 'Assembly Contigs' to filter_input_objects for upstream selection logic in scheduler.
- Enhanced `sched::create_job_rec` - Logic now selects upstream data objects based on 'filter_input_objects' configuration.
- Fixed 'NoneType' crash in `wfutils` - Ensured Path creation called after safely checking value retrial; Improved handling of missing optional outputs gracefully.
- Added unit tests and fixtures: Verified fixes for missing outputs and confirmed correct upstream contigs data object selection for MAGs.