### PR TITLE
update incrementation logic

### DIFF
--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -305,22 +305,16 @@ class Scheduler:
         See if anything exist for this and if not
         mint a new id.
         """
-        # We need to see if any version exist and
-        # if so get its ID
-        ct = 0
-        last_id = None
-        
-        # Only look for ID for informed_by len=1, and handle multi later -jlp 20250722
-        # This should be ok to pass the array of was_informed_by to find the workflow in mongo -jlp 20250828
-        #if len(informed_by) == 1:
+        last_iteration = None
+
         q = {"was_informed_by": informed_by, "type": wf.type}
         #for doc in self.db[wf.collection].find(q):
         for doc in self.api.list_from_collection(wf.collection, q, "id"):
-            ct += 1
-            last_id = doc["id"]
+            curr_iteration = int(doc["id"].split(".")[-1])
+            if last_iteration is None or curr_iteration > last_iteration:
+                last_iteration = curr_iteration
 
-
-        if ct == 0 or last_id is None:
+        if last_iteration is None:
             # Get an ID
             if os.environ.get("MOCK_MINT"):
                 root_id = self.mock_mint(wf.type)
@@ -328,8 +322,8 @@ class Scheduler:
                 root_id = self.api.minter(wf.type, informed_by)
             return root_id, 1
         else:
-            root_id = ".".join(last_id.split(".")[0:-1])
-            return root_id, ct + 1
+            root_id = ".".join(doc["id"].split(".")[0:-1])
+            return root_id, last_iteration + 1
 
     @lru_cache(maxsize=128)
     def get_existing_jobs(self, wf: WorkflowConfig):

--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -305,16 +305,26 @@ class Scheduler:
         See if anything exist for this and if not
         mint a new id.
         """
+        last_time = None
         last_iteration = None
+        last_root = None
+
 
         q = {"was_informed_by": informed_by, "type": wf.type}
-        #for doc in self.db[wf.collection].find(q):
-        for doc in self.api.list_from_collection(wf.collection, q, "id"):
-            curr_iteration = int(doc["id"].split(".")[-1])
-            if last_iteration is None or curr_iteration > last_iteration:
-                last_iteration = curr_iteration
+        for doc in self.api.list_from_collection(wf.collection, q, "id, started_at_time"):
+            curr_root = ".".join(doc["id"].split(".")[0:-1])
+            if last_root is None or curr_root == last_root:
+                last_root = curr_root
+                curr_iteration = int(doc["id"].split(".")[-1])
+                if last_iteration is None or curr_iteration > last_iteration:
+                    last_iteration = curr_iteration
+            else:
+                if doc["started_at_time"] > last_time:
+                    last_time = doc["started_at_time"]
+                    last_root = curr_root
+                    last_iteration = int(doc["id"].split(".")[-1])
 
-        if last_iteration is None:
+        if last_root is None and last_iteration is None:
             # Get an ID
             if os.environ.get("MOCK_MINT"):
                 root_id = self.mock_mint(wf.type)
@@ -322,7 +332,7 @@ class Scheduler:
                 root_id = self.api.minter(wf.type, informed_by)
             return root_id, 1
         else:
-            root_id = ".".join(doc["id"].split(".")[0:-1])
+            root_id = last_root
             return root_id, last_iteration + 1
 
     @lru_cache(maxsize=128)

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -1067,3 +1067,24 @@ def test_scheduler_mags_priority_selection(test_db, test_client, workflows_confi
     # since only Assembly has a BAM, it should be picked up even if not in filters
     bam_id = "nmdc:dobj-11-t4b20t83" # Assuming this is the BAM ID in your fixture
     assert bam_id in selected_ids
+
+def test_get_activity_id_existing(test_db, test_client, workflows_config_dir, site_config_file):
+    """get_activity_id returns the next iteration when a matching record already exists."""
+    reset_db(test_db)
+
+    jm = Scheduler(workflow_yaml=workflows_config_dir / "workflows.yaml",
+                   site_conf=site_config_file, api=test_client)
+    wf = next(w for w in jm.workflows if w.name == "Reads QC")
+    informed_by = ["nmdc:dgns-11-abc123"]
+
+    # Seed an existing execution record with a iteration >1
+    test_db[wf.collection].insert_one({
+        "id": "nmdc:wfrqc-11-existing.3",
+        "was_informed_by": informed_by,
+        "type": wf.type,
+    })
+
+    base_id, iteration = jm.get_activity_id(wf, informed_by)
+
+    assert base_id == "nmdc:wfrqc-11-existing"
+    assert iteration == 4


### PR DESCRIPTION
update incrementation logic so its reliant on the latest iteration instead of the number of records. relying on the number of records becomes problematic when previous records have been deleted, see #729. I'm uncertain if this is how we want to handle situations where a single dg id has workflows of the same type with more than one root id