### PR TITLE
update workflows.yaml for MAGs default to not use gpu for semibin2

### DIFF
--- a/nmdc_automation/config/workflows/workflows.yaml
+++ b/nmdc_automation/config/workflows/workflows.yaml
@@ -322,6 +322,7 @@ Workflows:
       lineage_file: do:Scaffold Lineage tsv
       map_file: do:Contig Mapping File
       seqtype: "short_reads"
+      use_gpu: false
     Optional Inputs:
       - map_file
     Workflow Execution:

--- a/tests/fixtures/mags_workflow_state.json
+++ b/tests/fixtures/mags_workflow_state.json
@@ -28,7 +28,8 @@
           "product_names_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-hwz45c12/nmdc:wfmgan-12-1hfw7y63.1/nmdc_wfmgan-12-1hfw7y63.1_product_names.tsv",
           "gene_phylogeny_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-hwz45c12/nmdc:wfmgan-12-1hfw7y63.1/nmdc_wfmgan-12-1hfw7y63.1_gene_phylogeny.tsv",
           "lineage_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-hwz45c12/nmdc:wfmgan-12-1hfw7y63.1/nmdc_wfmgan-12-1hfw7y63.1_scaffold_lineage.tsv",
-          "map_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-hwz45c12/nmdc:wfmgan-12-1hfw7y63.1/nmdc_wfmgan-12-1hfw7y63.1_contig_names_mapping.tsv"
+          "map_file": "https://data.microbiomedata.org/data/nmdc:omprc-11-hwz45c12/nmdc:wfmgan-12-1hfw7y63.1/nmdc_wfmgan-12-1hfw7y63.1_contig_names_mapping.tsv",
+          "use_gpu": false
         },
         "input_data_objects": [
           {


### PR DESCRIPTION
Updated workflows.yaml default for use_gpu flag to false in the MAGs workflow; added it to a MAGs test fixture to observe the update in the pytest outputs (test mongo, job rec, and tmp.json). 