### PR TITLE
742 update get existing jobs to support manifest filtering

### DIFF
--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -376,12 +376,15 @@ class Scheduler:
             return root_id, last_iteration + 1
 
     @lru_cache(maxsize=128)
-    def get_existing_jobs(self, wf: WorkflowConfig):
+    def get_existing_jobs(self, wf: WorkflowConfig, manifest_id: str = None):
         """
         we return an existing job if an exact version match was found,
         no other version is currently running, 
         and no existing version is newer than our current config (so that we don't schedule 
         a downgraded new job record). 
+
+        Added: manifest_id filter to allow re-pooling data generation IDs 
+        that were previously run as individual (non-manifest) jobs.
         """
         existing_jobs = set()
 
@@ -393,11 +396,24 @@ class Scheduler:
         current_v = get_v_obj(wf.version)
         
         q = {"config.git_repo": wf.git_repo}
+
+        # If we are evaluating a manifest pool, target jobs matching this manifest
+        if manifest_id:
+            q["config.manifest"] = manifest_id
         
         for j in self.api.list_jobs(q):
             # the assumption is that a job in any state has been triggered by an activity
             # that was the result of an existing (completed) job
             act = j["config"]["trigger_activity"]
+
+            if not manifest_id and j["config"].get("manifest"):
+                logger.warning(
+                    f"Data integrity mismatch for activity {act}: Live data object is individual, "
+                    f"but historical job {j.get('id')} was run as part of manifest '{j['config']['manifest']}'. "
+                    f"Upstream database may have changed. Proceeding with individual scheduling."
+                )
+                continue
+            
             job_version_str = j["config"].get("release")
             job_v = get_v_obj(job_version_str)
             claims = j.get("claims", [])
@@ -469,6 +485,10 @@ class Scheduler:
         - Is for a workflow that is enabled
         """
         new_jobs = []
+
+        # Extract current manifest string if it exists for this node
+        current_manifest_id = wfp_node.manifest[0] if len(wfp_node.manifest) == 1 else None
+
         # Loop over the derived workflows for this
         # activities' workflow
         for wf in wfp_node.workflow.children:
@@ -480,7 +500,7 @@ class Scheduler:
                     self._messages.append(msg)
                 continue
             # See if we already have a job for this
-            if wfp_node.id in self.get_existing_jobs(wf):
+            if wfp_node.id in self.get_existing_jobs(wf, manifest_id=current_manifest_id):
                 msg = f"Skipping existing job for {wfp_node.id} {wf.name}:{wf.version}"
                 if msg not in self._messages:
                     logger.info(msg)
@@ -500,7 +520,7 @@ class Scheduler:
                     for dgns_id in manifest_map[wfp_node.manifest[0]]['data_generation_set']:
                         # Only need to check for others dgns since already checked itself above
                         if dgns_id != wfp_node.id:
-                            if dgns_id in self.get_existing_jobs(wf):
+                            if dgns_id in self.get_existing_jobs(wf, manifest_id=current_manifest_id):
                                 found_existing_manifest_job = True
                                 associated_wfp_node_id = dgns_id
                                 break

--- a/tests/fixtures/nmdc_db/data_generation_in_manifest_update.json
+++ b/tests/fixtures/nmdc_db/data_generation_in_manifest_update.json
@@ -1,0 +1,59 @@
+[{
+  "id": "nmdc:dgns-11-kwb7eq83",
+  "type": "nmdc:NucleotideSequencing",
+  "name": "Terrestrial soil microbial communities - STER_028-M-20170605-COMP-DNA1 (BMI_HFWLLBGX7_Plate68WellC3)",
+  "has_output": [
+    "nmdc:dobj-11-xdqgt848",
+    "nmdc:dobj-11-4kx0h490"
+  ],
+  "has_input": [
+    "nmdc:procsm-11-1v407908"
+  ],
+  "associated_studies": [
+    "nmdc:sty-11-34xj1150"
+  ],
+  "instrument_used": [
+    "nmdc:inst-14-xz5tb342"
+  ],
+  "processing_institution": "Battelle",
+  "ncbi_project_name": "PRJNA406974",
+  "analyte_category": "metagenome",
+  "gold_sequencing_project_identifiers": [
+    "gold:Gp0766865"
+  ],
+  "provenance_metadata": {
+    "type": "nmdc:ProvenanceMetadata",
+    "add_date": "2026-06-11T21:52:15Z",
+    "source_system_of_record": "NEON_Data_Portal",
+    "git_url": "https://github.com/microbiomedata/nmdc-runtime",
+    "mod_date": "2026-06-11T21:52:17Z"
+  }
+},
+{
+  "id": "nmdc:dgns-11-syr2vn62",
+  "type": "nmdc:NucleotideSequencing",
+  "name": "Terrestrial soil microbial communities - STER_028-M-20170605-COMP-DNA1",
+  "has_input": [
+    "nmdc:procsm-11-1v407908"
+  ],
+  "has_output": [
+    "nmdc:dobj-11-kpt53f77",
+    "nmdc:dobj-11-tv9g1670"
+  ],
+  "processing_institution": "Battelle",
+  "analyte_category": "metagenome",
+  "associated_studies": [
+    "nmdc:sty-11-34xj1150"
+  ],
+  "instrument_used": [
+    "nmdc:inst-14-xz5tb342"
+  ],
+  "ncbi_project_name": "PRJNA406974",
+  "gold_sequencing_project_identifiers": [
+    "gold:Gp0766865"
+  ],
+  "provenance_metadata": {
+    "type": "nmdc:ProvenanceMetadata",
+    "mod_date": "2026-04-21T03:57:56Z"
+  }
+}]

--- a/tests/fixtures/nmdc_db/data_object_set.agg.json
+++ b/tests/fixtures/nmdc_db/data_object_set.agg.json
@@ -7,7 +7,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube93_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube93_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -19,7 +19,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube93_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube93_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -31,7 +31,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube93_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube93_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -43,7 +43,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube93_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube93_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -55,7 +55,7 @@
   ],
   "name": "BMI_22A_01_0002_mms_HNFFKBGXN_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HNFFKBGXN_R2/BMI_22A_01_0002_mms_HNFFKBGXN_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -67,7 +67,7 @@
   ],
   "name": "BMI_22A_01_0002_mms_HNFFKBGXN_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HNFFKBGXN_R1/BMI_22A_01_0002_mms_HNFFKBGXN_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -79,7 +79,7 @@
   ],
   "name": "BMI_22A_01_0002_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2024/HTLW3DSX7_PoolA_R1/BMI_22A_01_0002_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -91,7 +91,7 @@
   ],
   "name": "BMI_22A_01_0002_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2024/HTLW3DSX7_PoolA_R2/BMI_22A_01_0002_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -103,7 +103,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube86_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube86_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -115,7 +115,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube86_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube86_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -127,7 +127,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube86_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube86_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -139,7 +139,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube86_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube86_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -151,7 +151,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube86_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube86_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -163,7 +163,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube86_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube86_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -175,7 +175,7 @@
   ],
   "name": "BMI_22A_01_0001_mms_HNFFKBGXN_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HNFFKBGXN_R1/BMI_22A_01_0001_mms_HNFFKBGXN_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -187,7 +187,7 @@
   ],
   "name": "BMI_22A_01_0001_mms_HNFFKBGXN_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HNFFKBGXN_R2/BMI_22A_01_0001_mms_HNFFKBGXN_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -199,7 +199,7 @@
   ],
   "name": "BMI_22A_01_0001_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2024/HTLW3DSX7_PoolA_R1/BMI_22A_01_0001_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -211,7 +211,7 @@
   ],
   "name": "BMI_22A_01_0001_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2024/HTLW3DSX7_PoolA_R2/BMI_22A_01_0001_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -223,7 +223,7 @@
   ],
   "name": "BMI_HFWM2BGX7_Tube630_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM2BGX7_mms_R2/BMI_HFWM2BGX7_Tube630_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -235,7 +235,7 @@
   ],
   "name": "BMI_HFWM2BGX7_Tube630_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM2BGX7_mms_R1/BMI_HFWM2BGX7_Tube630_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -247,7 +247,7 @@
   ],
   "name": "BMI_HVG3TBGX5_Tube630_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HVG3TBGX5_mms_R2/BMI_HVG3TBGX5_Tube630_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -259,7 +259,7 @@
   ],
   "name": "BMI_HVG3TBGX5_Tube630_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HVG3TBGX5_mms_R1/BMI_HVG3TBGX5_Tube630_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -271,7 +271,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube34_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube34_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -283,7 +283,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube34_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube34_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -295,7 +295,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube34_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube34_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -307,7 +307,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube34_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube34_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -319,7 +319,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube34_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube34_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -331,7 +331,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube34_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube34_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -343,7 +343,7 @@
   ],
   "name": "BMI_HFWM2BGX7_Tube202_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM2BGX7_mms_R1/BMI_HFWM2BGX7_Tube202_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -355,7 +355,7 @@
   ],
   "name": "BMI_HFWM2BGX7_Tube202_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM2BGX7_mms_R2/BMI_HFWM2BGX7_Tube202_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -367,7 +367,7 @@
   ],
   "name": "BMI_HVJHMBGX5_Tube202_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HVJHMBGX5_mms_R1/BMI_HVJHMBGX5_Tube202_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -379,7 +379,7 @@
   ],
   "name": "BMI_HVJHMBGX5_Tube202_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HVJHMBGX5_mms_R2/BMI_HVJHMBGX5_Tube202_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -391,7 +391,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube42_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube42_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -403,7 +403,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube42_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube42_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -415,7 +415,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube42_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube42_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -427,7 +427,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube42_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube42_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -439,7 +439,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube42_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube42_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -451,7 +451,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube42_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube42_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -463,7 +463,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube48_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube48_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -475,7 +475,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube48_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube48_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -487,7 +487,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube48_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube48_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -499,7 +499,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube48_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube48_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -511,7 +511,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube48_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube48_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -523,7 +523,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube48_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube48_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -535,7 +535,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube45_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube45_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -547,7 +547,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube45_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube45_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -559,7 +559,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube45_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube45_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -571,7 +571,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube45_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube45_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -583,7 +583,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube45_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube45_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -595,7 +595,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube45_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube45_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -607,7 +607,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube52_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube52_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -619,7 +619,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube52_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube52_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -631,7 +631,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube52_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube52_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -643,7 +643,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube52_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube52_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -655,7 +655,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube52_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube52_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -667,7 +667,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube52_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube52_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -679,7 +679,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube43_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube43_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -691,7 +691,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube43_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube43_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -703,7 +703,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube43_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube43_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -715,7 +715,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube43_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube43_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -727,7 +727,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube43_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube43_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -739,7 +739,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube43_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube43_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -751,7 +751,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube51_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube51_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -763,7 +763,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube51_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube51_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -775,7 +775,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube51_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube51_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -787,7 +787,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube51_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube51_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -799,7 +799,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube51_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube51_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -811,7 +811,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube51_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube51_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -823,7 +823,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube49_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube49_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -835,7 +835,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube49_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube49_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -847,7 +847,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube49_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube49_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -859,7 +859,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube49_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube49_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -871,7 +871,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube49_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube49_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -883,7 +883,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube49_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube49_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -895,7 +895,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube50_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube50_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -907,7 +907,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube50_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube50_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -919,7 +919,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube50_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube50_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -931,7 +931,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube50_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube50_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -943,7 +943,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube50_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube50_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -955,7 +955,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube50_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube50_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -967,7 +967,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube77_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube77_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -979,7 +979,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube77_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube77_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -991,7 +991,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube77_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube77_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1003,7 +1003,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube77_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube77_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1015,7 +1015,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube77_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube77_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1027,7 +1027,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube77_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube77_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1039,7 +1039,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube78_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube78_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1051,7 +1051,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube78_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube78_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1063,7 +1063,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube78_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube78_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1075,7 +1075,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube78_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube78_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1087,7 +1087,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube80_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube80_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1099,7 +1099,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube80_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube80_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1111,7 +1111,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube80_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube80_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1123,7 +1123,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube80_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube80_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1135,7 +1135,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube74_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube74_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1147,7 +1147,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube74_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube74_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1159,7 +1159,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube74_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube74_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1171,7 +1171,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube74_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube74_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1183,7 +1183,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube74_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube74_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1195,7 +1195,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube74_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube74_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1207,7 +1207,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube79_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube79_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1219,7 +1219,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube79_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube79_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1231,7 +1231,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube79_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube79_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1243,7 +1243,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube79_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube79_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1255,7 +1255,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube79_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube79_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1267,7 +1267,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube79_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube79_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1279,7 +1279,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube81_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube81_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1291,7 +1291,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube81_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube81_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1303,7 +1303,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube81_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube81_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1315,7 +1315,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube81_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube81_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1327,7 +1327,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube81_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube81_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1339,7 +1339,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube81_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube81_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1351,7 +1351,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube76_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube76_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1363,7 +1363,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube76_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube76_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1375,7 +1375,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube76_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube76_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1387,7 +1387,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube76_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube76_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1399,7 +1399,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube76_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube76_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1411,7 +1411,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube76_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube76_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1423,7 +1423,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube75_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube75_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1435,7 +1435,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube75_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube75_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1447,7 +1447,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube75_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube75_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1459,7 +1459,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube75_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube75_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1471,7 +1471,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube75_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube75_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1483,7 +1483,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube75_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube75_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1495,7 +1495,7 @@
   ],
   "name": "BMI_HL7HTBGX7_Tube1247_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HL7HTBGX7_mms_R2/BMI_HL7HTBGX7_Tube1247_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1507,7 +1507,7 @@
   ],
   "name": "BMI_HFWM2BGX7_Tube1247_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM2BGX7_mms_R1/BMI_HFWM2BGX7_Tube1247_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1519,7 +1519,7 @@
   ],
   "name": "BMI_HFWM2BGX7_Tube1247_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM2BGX7_mms_R2/BMI_HFWM2BGX7_Tube1247_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1531,7 +1531,7 @@
   ],
   "name": "BMI_HL7HTBGX7_Tube1247_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HL7HTBGX7_mms_R1/BMI_HL7HTBGX7_Tube1247_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1543,7 +1543,7 @@
   ],
   "name": "BMI_HL7HTBGX7_Tube1250_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HL7HTBGX7_mms_R2/BMI_HL7HTBGX7_Tube1250_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1555,7 +1555,7 @@
   ],
   "name": "BMI_HFWM2BGX7_Tube1250_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM2BGX7_mms_R2/BMI_HFWM2BGX7_Tube1250_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1567,7 +1567,7 @@
   ],
   "name": "BMI_HL7HTBGX7_Tube1250_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HL7HTBGX7_mms_R1/BMI_HL7HTBGX7_Tube1250_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1579,7 +1579,7 @@
   ],
   "name": "BMI_HFWM2BGX7_Tube1250_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM2BGX7_mms_R1/BMI_HFWM2BGX7_Tube1250_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1591,7 +1591,7 @@
   ],
   "name": "BMI_HVG3TBGX5_Tube634_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HVG3TBGX5_mms_R1/BMI_HVG3TBGX5_Tube634_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1603,7 +1603,7 @@
   ],
   "name": "BMI_HFWM2BGX7_Tube634_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM2BGX7_mms_R2/BMI_HFWM2BGX7_Tube634_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1615,7 +1615,7 @@
   ],
   "name": "BMI_HFWM2BGX7_Tube634_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM2BGX7_mms_R1/BMI_HFWM2BGX7_Tube634_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1627,7 +1627,7 @@
   ],
   "name": "BMI_HVG3TBGX5_Tube634_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HVG3TBGX5_mms_R2/BMI_HVG3TBGX5_Tube634_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1639,7 +1639,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube27_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube27_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1651,7 +1651,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube27_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube27_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1663,7 +1663,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube27_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube27_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1675,7 +1675,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube27_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube27_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1687,7 +1687,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube27_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube27_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1699,7 +1699,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube27_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube27_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1711,7 +1711,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube26_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube26_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1723,7 +1723,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube26_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube26_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1735,7 +1735,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube26_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube26_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1747,7 +1747,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube26_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube26_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1759,7 +1759,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube26_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube26_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1771,7 +1771,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube26_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube26_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1783,7 +1783,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube25_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube25_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1795,7 +1795,7 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube25_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube25_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1807,7 +1807,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube25_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube25_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1819,7 +1819,7 @@
   ],
   "name": "BMI_HLGJLBGX5_Tube25_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube25_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1831,7 +1831,7 @@
   ],
   "name": "BMI_HHWLYBGX5_Tube25_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube25_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -1843,6 +1843,6 @@
   ],
   "name": "BMI_HCNKKBGX5_Tube25_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube25_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 }]

--- a/tests/fixtures/nmdc_db/data_objects_4.json
+++ b/tests/fixtures/nmdc_db/data_objects_4.json
@@ -7,7 +7,7 @@
   "data_object_type": "Read Filtering Info File",
   "file_size_bytes": 620,
   "md5_checksum": "436b791048f5c24824d1a29b02e6004b",
-  "url": "https://data.microbiomedata.org/data/nmdc:dgns-15-bvywdf28/nmdc:wfrqc-11-avb69r07.1/nmdc_wfrqc-11-avb69r07.1_readsQC.info",
+  "url": "https://data.microbiomedata.org",
   "was_generated_by": "nmdc:wfrqc-11-avb69r07.1"
 },
 {
@@ -19,7 +19,7 @@
   "data_object_type": "QC Statistics",
   "file_size_bytes": 275,
   "md5_checksum": "38afc701ce56a562e9c4d7a2fe47a4f0",
-  "url": "https://data.microbiomedata.org/data/nmdc:dgns-15-bvywdf28/nmdc:wfrqc-11-avb69r07.1/nmdc_wfrqc-11-avb69r07.1_filterStats.txt",
+  "url": "https://data.microbiomedata.org",
   "was_generated_by": "nmdc:wfrqc-11-avb69r07.1"
 },
 {
@@ -31,7 +31,7 @@
   "data_object_type": "Filtered Sequencing Reads",
   "file_size_bytes": 1626931248,
   "md5_checksum": "61b454b8e9a2f9802d7359a593cbafdc",
-  "url": "https://data.microbiomedata.org/data/nmdc:dgns-15-bvywdf28/nmdc:wfrqc-11-avb69r07.1/nmdc_wfrqc-11-avb69r07.1_filtered.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "was_generated_by": "nmdc:wfrqc-11-avb69r07.1"
 },
 {
@@ -42,7 +42,7 @@
   "md5_checksum": "e31aa5fbbe6e2b9fc1383779fa44be70",
   "name": "BMI_21S_23_2077_mms_HN27GBGXN_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HN27GBGXN_R1/BMI_21S_23_2077_mms_HN27GBGXN_R1.fastq.gz"
+  "url": "https://data.microbiomedata.org"
 },
 {
   "data_category": "instrument_data",
@@ -52,5 +52,5 @@
   "md5_checksum": "c2966c77d5630f705b0249a98ab1144d",
   "name": "BMI_21S_23_2077_mms_HN27GBGXN_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HN27GBGXN_R2/BMI_21S_23_2077_mms_HN27GBGXN_R2.fastq.gz"
+  "url": "https://data.microbiomedata.org"
 }]

--- a/tests/fixtures/nmdc_db/data_objects_5.json
+++ b/tests/fixtures/nmdc_db/data_objects_5.json
@@ -5,7 +5,7 @@
   "md5_checksum": "818d0bc4bff45f46c9d3630ffbb80cd4",
   "name": "BMI_HY5W2BGXG_Plate19S_31WellG3_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2020/BMI_HY5W2BGXG_mms_R2/BMI_HY5W2BGXG_Plate19S_31WellG3_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -15,7 +15,7 @@
   "md5_checksum": "fd75ef2c0fdabcb7144053ef091fe41b",
   "name": "BMI_HY5W2BGXG_Plate19S_31WellG3_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2020/BMI_HY5W2BGXG_mms_R1/BMI_HY5W2BGXG_Plate19S_31WellG3_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -26,7 +26,7 @@
   "md5_checksum": "d3f0ef6b28ed64a421a34ef3635f8eb5",
   "name": "BMI_21S_24_2195_mms_H2WYNBGXT_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/H2WYNBGXT_R2/BMI_21S_24_2195_mms_H2WYNBGXT_R2.fastq.gz"
+  "url": "https://data.microbiomedata.org"
 },
 {
   "data_category": "instrument_data",
@@ -36,7 +36,7 @@
   "md5_checksum": "e31aa5fbbe6e2b9fc1383779fa44be70",
   "name": "BMI_21S_23_2077_mms_HN27GBGXN_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HN27GBGXN_R1/BMI_21S_23_2077_mms_HN27GBGXN_R1.fastq.gz"
+  "url": "https://data.microbiomedata.org"
 },
 {
   "data_category": "instrument_data",
@@ -46,7 +46,7 @@
   "md5_checksum": "c2966c77d5630f705b0249a98ab1144d",
   "name": "BMI_21S_23_2077_mms_HN27GBGXN_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HN27GBGXN_R2/BMI_21S_23_2077_mms_HN27GBGXN_R2.fastq.gz"
+  "url": "https://data.microbiomedata.org"
 },
 {
   "data_category": "instrument_data",
@@ -56,5 +56,5 @@
   "md5_checksum": "ed239b98ca836f4105638de895aa534c",
   "name": "BMI_21S_24_2195_mms_H2WYNBGXT_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/H2WYNBGXT_R1/BMI_21S_24_2195_mms_H2WYNBGXT_R1.fastq.gz"
+  "url": "https://data.microbiomedata.org"
 }]

--- a/tests/fixtures/nmdc_db/data_objects_in_manifest_2.json
+++ b/tests/fixtures/nmdc_db/data_objects_in_manifest_2.json
@@ -8,7 +8,7 @@
         ],
         "name": "BMI_HCNKKBGX5_Tube75_R2.fastq.gz",
         "type": "nmdc:DataObject",
-        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube75_R2.fastq.gz",
+        "url": "https://data.microbiomedata.org",
         "data_category": "instrument_data"
     },
     {
@@ -20,7 +20,7 @@
         ],
         "name": "BMI_HL7HTBGX7_Tube1250_R2.fastq.gz",
         "type": "nmdc:DataObject",
-        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HL7HTBGX7_mms_R2/BMI_HL7HTBGX7_Tube1250_R2.fastq.gz",
+        "url": "https://data.microbiomedata.org",
         "data_category": "instrument_data"
     },
     {
@@ -32,7 +32,7 @@
         ],
         "name": "BMI_HHWLYBGX5_Tube75_R1.fastq.gz",
         "type": "nmdc:DataObject",
-        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R1/BMI_HHWLYBGX5_Tube75_R1.fastq.gz",
+        "url": "https://data.microbiomedata.org",
         "data_category": "instrument_data"
     },
     {
@@ -44,7 +44,7 @@
         ],
         "name": "BMI_HFWM2BGX7_Tube1250_R1.fastq.gz",
         "type": "nmdc:DataObject",
-        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM2BGX7_mms_R1/BMI_HFWM2BGX7_Tube1250_R1.fastq.gz",
+        "url": "https://data.microbiomedata.org",
         "data_category": "instrument_data"
     },
     {
@@ -56,7 +56,7 @@
         ],
         "name": "BMI_HL7HTBGX7_Tube1250_R1.fastq.gz",
         "type": "nmdc:DataObject",
-        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HL7HTBGX7_mms_R1/BMI_HL7HTBGX7_Tube1250_R1.fastq.gz",
+        "url": "https://data.microbiomedata.org",
         "data_category": "instrument_data"
     },
     {
@@ -68,7 +68,7 @@
         ],
         "name": "BMI_HLGJLBGX5_Tube75_R2.fastq.gz",
         "type": "nmdc:DataObject",
-        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube75_R2.fastq.gz",
+        "url": "https://data.microbiomedata.org",
         "data_category": "instrument_data"
     },
     {
@@ -80,7 +80,7 @@
         ],
         "name": "BMI_HLGJLBGX5_Tube75_R1.fastq.gz",
         "type": "nmdc:DataObject",
-        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube75_R1.fastq.gz",
+        "url": "https://data.microbiomedata.org",
         "data_category": "instrument_data"
     },
     {
@@ -92,7 +92,7 @@
         ],
         "name": "BMI_HHWLYBGX5_Tube75_R2.fastq.gz",
         "type": "nmdc:DataObject",
-        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HHWLYBGX5_mms_R2/BMI_HHWLYBGX5_Tube75_R2.fastq.gz",
+        "url": "https://data.microbiomedata.org",
         "data_category": "instrument_data"
     },
     {
@@ -104,7 +104,7 @@
         ],
         "name": "BMI_HFWM2BGX7_Tube1250_R2.fastq.gz",
         "type": "nmdc:DataObject",
-        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM2BGX7_mms_R2/BMI_HFWM2BGX7_Tube1250_R2.fastq.gz",
+        "url": "https://data.microbiomedata.org",
         "data_category": "instrument_data"
     },
     {
@@ -116,7 +116,7 @@
         ],
         "name": "BMI_HCNKKBGX5_Tube75_R1.fastq.gz",
         "type": "nmdc:DataObject",
-        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube75_R1.fastq.gz",
+        "url": "https://data.microbiomedata.org",
         "data_category": "instrument_data"
     }
 ]

--- a/tests/fixtures/nmdc_db/data_objects_in_manifest_3.json
+++ b/tests/fixtures/nmdc_db/data_objects_in_manifest_3.json
@@ -8,7 +8,7 @@
   ],
   "name": "BMI_22A_01_0002_mms_HNFFKBGXN_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HNFFKBGXN_R1/BMI_22A_01_0002_mms_HNFFKBGXN_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -20,7 +20,7 @@
   ],
   "name": "BMI_22A_01_0002_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2024/HTLW3DSX7_PoolA_R2/BMI_22A_01_0002_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -32,7 +32,7 @@
   ],
   "name": "BMI_22A_01_0002_mms_HNFFKBGXN_R2.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/HNFFKBGXN_R2/BMI_22A_01_0002_mms_HNFFKBGXN_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -44,7 +44,7 @@
   ],
   "name": "BMI_22A_01_0002_R1.fastq.gz",
   "type": "nmdc:DataObject",
-  "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2024/HTLW3DSX7_PoolA_R1/BMI_22A_01_0002_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "data_category": "instrument_data"
 },
 {
@@ -56,7 +56,7 @@
   "data_object_type": "Read Filtering Info File",
   "file_size_bytes": 620,
   "md5_checksum": "436b791048f5c24824d1a29b02e6004b",
-  "url": "https://data.microbiomedata.org/data/dev/nmdc:manif-11-jyrzrd96/nmdc:wfrqc-15-x027k720.1/nmdc_wfrqc-15-x027k720.1_readsQC.info",
+  "url": "https://data.microbiomedata.org",
   "was_generated_by": "nmdc:wfrqc-15-x027k720.1"
 },
 {
@@ -68,7 +68,7 @@
   "data_object_type": "Filtered Sequencing Reads",
   "file_size_bytes": 462030159,
   "md5_checksum": "d09b6b265e6564793aead3203f653c83",
-  "url": "https://data.microbiomedata.org/data/dev/nmdc:manif-11-jyrzrd96/nmdc:wfrqc-15-x027k720.1/nmdc_wfrqc-15-x027k720.1_filtered.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "was_generated_by": "nmdc:wfrqc-15-x027k720.1"
 },
 {
@@ -80,7 +80,7 @@
   "data_object_type": "QC Statistics",
   "file_size_bytes": 287,
   "md5_checksum": "a970cbeaf7f1028d27988f3017fee0c2",
-  "url": "https://data.microbiomedata.org/data/dev/nmdc:manif-11-jyrzrd96/nmdc:wfrqc-15-x027k720.1/nmdc_wfrqc-15-x027k720.1_filterStats.txt",
+  "url": "https://data.microbiomedata.org",
   "was_generated_by": "nmdc:wfrqc-15-x027k720.1"
 }
 ]

--- a/tests/fixtures/nmdc_db/data_objects_in_manifest_downstream.json
+++ b/tests/fixtures/nmdc_db/data_objects_in_manifest_downstream.json
@@ -8,7 +8,7 @@
     ],
     "name": "BMI_HCNKKBGX5_Tube93_R1.fastq.gz",
     "type": "nmdc:DataObject",
-    "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R1/BMI_HCNKKBGX5_Tube93_R1.fastq.gz",
+    "url": "https://data.microbiomedata.org",
     "data_category": "instrument_data"
   },
   {
@@ -20,7 +20,7 @@
     ],
     "name": "BMI_HCNKKBGX5_Tube93_R2.fastq.gz",
     "type": "nmdc:DataObject",
-    "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HCNKKBGX5_mms_R2/BMI_HCNKKBGX5_Tube93_R2.fastq.gz",
+    "url": "https://data.microbiomedata.org",
     "data_category": "instrument_data"
   },
   {
@@ -32,7 +32,7 @@
     ],
     "name": "BMI_HLGJLBGX5_Tube93_R1.fastq.gz",
     "type": "nmdc:DataObject",
-    "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R1/BMI_HLGJLBGX5_Tube93_R1.fastq.gz",
+    "url": "https://data.microbiomedata.org",
     "data_category": "instrument_data"
   },
   {
@@ -44,7 +44,7 @@
     ],
     "name": "BMI_HLGJLBGX5_Tube93_R2.fastq.gz",
     "type": "nmdc:DataObject",
-    "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HLGJLBGX5_mms_R2/BMI_HLGJLBGX5_Tube93_R2.fastq.gz",
+    "url": "https://data.microbiomedata.org",
     "data_category": "instrument_data"
   },
   {
@@ -56,7 +56,7 @@
   "data_object_type": "Filtered Sequencing Reads",
   "file_size_bytes": 1784035188,
   "md5_checksum": "24106eaa91ec4d02e4287bffccaf020a",
-  "url": "https://data.microbiomedata.org/data/dev/nmdc:manif-11-behhtd03/nmdc:wfrqc-15-8rcjpy94.1/nmdc_wfrqc-15-8rcjpy94.1_filtered.fastq.gz",
+  "url": "https://data.microbiomedata.org",
   "was_generated_by": "nmdc:wfrqc-15-8rcjpy94.1"
   },
   {
@@ -68,7 +68,7 @@
   "data_object_type": "Read Filtering Info File",
   "file_size_bytes": 620,
   "md5_checksum": "436b791048f5c24824d1a29b02e6004b",
-  "url": "https://data.microbiomedata.org/data/dev/nmdc:manif-11-behhtd03/nmdc:wfrqc-15-8rcjpy94.1/nmdc_wfrqc-15-8rcjpy94.1_readsQC.info",
+  "url": "https://data.microbiomedata.org",
   "was_generated_by": "nmdc:wfrqc-15-8rcjpy94.1"
   },
  {
@@ -80,7 +80,7 @@
   "data_object_type": "QC Statistics",
   "file_size_bytes": 282,
   "md5_checksum": "1700fd3f1762f48fc74525ead9f510c1",
-  "url": "https://data.microbiomedata.org/data/dev/nmdc:manif-11-behhtd03/nmdc:wfrqc-15-8rcjpy94.1/nmdc_wfrqc-15-8rcjpy94.1_filterStats.txt",
+  "url": "https://data.microbiomedata.org",
   "was_generated_by": "nmdc:wfrqc-15-8rcjpy94.1"
  }
 ]

--- a/tests/fixtures/nmdc_db/data_objects_in_manifest_update.json
+++ b/tests/fixtures/nmdc_db/data_objects_in_manifest_update.json
@@ -1,0 +1,88 @@
+[{
+  "id": "nmdc:dobj-11-4kx0h490",
+  "name": "BMI_HFWLLBGX7_Plate68WellC3_R2.fastq.gz",
+  "url": "https://data.microbiomedata.org",
+  "description": "sequencing results for BMI_HFWLLBGX7_Plate68WellC3_R2",
+  "type": "nmdc:DataObject",
+  "data_category": "instrument_data",
+  "data_object_type": "Metagenome Raw Read 2",
+  "md5_checksum": "de636b75c791f62711864b4301c131b2",
+  "in_manifest": [
+    "nmdc:manif-11-f8gt6f52"
+  ]
+},
+{
+  "id": "nmdc:dobj-11-dpb8yd39",
+  "type": "nmdc:DataObject",
+  "name": "nmdc_wfrqc-11-2rg3xg37.1_filterStats.txt",
+  "description": "Reads QC summary for nmdc:wfrqc-11-2rg3xg37.1",
+  "data_category": "processed_data",
+  "data_object_type": "QC Statistics",
+  "file_size_bytes": 262,
+  "md5_checksum": "d0f1e9b15161cc33c162969f0e292613",
+  "url": "https://data.microbiomedata.org",
+  "was_generated_by": "nmdc:wfrqc-11-2rg3xg37.1"
+},
+{
+  "id": "nmdc:dobj-11-j5xkvb53",
+  "type": "nmdc:DataObject",
+  "name": "nmdc_wfrqc-11-2rg3xg37.1_readsQC.info",
+  "description": "Read filtering info for nmdc:wfrqc-11-2rg3xg37.1",
+  "data_category": "processed_data",
+  "data_object_type": "Read Filtering Info File",
+  "file_size_bytes": 620,
+  "md5_checksum": "436b791048f5c24824d1a29b02e6004b",
+  "url": "https://data.microbiomedata.org",
+  "was_generated_by": "nmdc:wfrqc-11-2rg3xg37.1"
+},
+{
+  "id": "nmdc:dobj-11-kpt53f77",
+  "type": "nmdc:DataObject",
+  "name": "BMI_HFWM5BGX7_Plate68WellC3_srt_R1.fastq.gz",
+  "description": "sequencing results for BMI_HFWM5BGX7_Plate68WellC3_srt_R1",
+  "data_object_type": "Metagenome Raw Read 1",
+  "md5_checksum": "0c8cd298c47550bb18e320ab380d2ddc",
+  "url": "https://data.microbiomedata.org",
+  "data_category": "instrument_data",
+  "in_manifest": [
+    "nmdc:manif-11-f8gt6f52"
+  ]
+},
+{
+  "id": "nmdc:dobj-11-r1dngr87",
+  "type": "nmdc:DataObject",
+  "name": "nmdc_wfrqc-11-2rg3xg37.1_filtered.fastq.gz",
+  "description": "Reads QC for nmdc:wfrqc-11-2rg3xg37.1",
+  "data_category": "processed_data",
+  "data_object_type": "Filtered Sequencing Reads",
+  "file_size_bytes": 224596346,
+  "md5_checksum": "1b98dbead8b2d8515ede70023f3e563d",
+  "url": "https://data.microbiomedata.org",
+  "was_generated_by": "nmdc:wfrqc-11-2rg3xg37.1"
+},
+{
+  "id": "nmdc:dobj-11-tv9g1670",
+  "type": "nmdc:DataObject",
+  "name": "BMI_HFWM5BGX7_Plate68WellC3_srt_R2.fastq.gz",
+  "description": "sequencing results for BMI_HFWM5BGX7_Plate68WellC3_srt_R2",
+  "data_object_type": "Metagenome Raw Read 2",
+  "md5_checksum": "2ecf576a571a4cd0b6b9a92261a2c720",
+  "url": "https://data.microbiomedata.org",
+  "data_category": "instrument_data",
+  "in_manifest": [
+    "nmdc:manif-11-f8gt6f52"
+  ]
+},
+{
+  "id": "nmdc:dobj-11-xdqgt848",
+  "name": "BMI_HFWLLBGX7_Plate68WellC3_R1.fastq.gz",
+  "url": "https://data.microbiomedata.org",
+  "description": "sequencing results for BMI_HFWLLBGX7_Plate68WellC3_R1",
+  "type": "nmdc:DataObject",
+  "data_category": "instrument_data",
+  "data_object_type": "Metagenome Raw Read 1",
+  "md5_checksum": "281d56cc8868c72729beed17218144c3",
+  "in_manifest": [
+    "nmdc:manif-11-f8gt6f52"
+  ]
+}]

--- a/tests/fixtures/nmdc_db/data_objects_multi.json
+++ b/tests/fixtures/nmdc_db/data_objects_multi.json
@@ -6,7 +6,7 @@
     "file_size_bytes": 299,
     "md5_checksum": "278a0b41e1a566f445b60268b5569829",
     "data_object_type": "Read Based Analysis Info File",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfrbt-11-y0bq8j10.1/nmdc_wfrbt-11-y0bq8j10.1_profiler.info",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -17,7 +17,7 @@
     "file_size_bytes": 1050063812,
     "md5_checksum": "73b2728cdcd58d5218dc85783d531a64",
     "data_object_type": "Clusters of Orthologous Groups (COG) Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_cog.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -28,7 +28,7 @@
     "file_size_bytes": 1124066215,
     "md5_checksum": "bb42c96e11100145aa376908fb1cc5f9",
     "data_object_type": "Genemark Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_genemark.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -39,7 +39,7 @@
     "file_size_bytes": 250050777,
     "md5_checksum": "84ddc6a52ebd69e20b81846a7accbccc",
     "data_object_type": "SMART Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_smart.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -50,7 +50,7 @@
     "file_size_bytes": 374139,
     "md5_checksum": "93b609d64eecba528109a7fbffb93486",
     "data_object_type": "Crispr Terms",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_crt.crisprs",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -61,7 +61,7 @@
     "file_size_bytes": 1846167706,
     "md5_checksum": "35a1cbc764251776be8c913cbb2ec306",
     "data_object_type": "Annotation Amino Acid FASTA",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_proteins.faa",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -72,7 +72,7 @@
     "file_size_bytes": 425,
     "md5_checksum": "21a3dd34fc0d5c23b3f37245f42691cb",
     "data_object_type": "Annotation Info File",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_imgap.info",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -83,7 +83,7 @@
     "file_size_bytes": 4313,
     "md5_checksum": "a1074848bebcba9ee99b5f2d5ebe2f9e",
     "data_object_type": "Assembly Info File",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgas-11-fw6wxd21.1/nmdc_wfmgas-11-fw6wxd21.1_metaAsm.info",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -94,7 +94,7 @@
     "file_size_bytes": 1219908954,
     "md5_checksum": "2e757b23bb1be12efbacce456ff1ba54",
     "data_object_type": "SUPERFam Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_supfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -105,7 +105,7 @@
     "file_size_bytes": 648132972,
     "md5_checksum": "31a55ad67212e108d8ca803663bdbf3f",
     "data_object_type": "Scaffold Lineage tsv",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_scaffold_lineage.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -116,7 +116,7 @@
     "file_size_bytes": 5055913,
     "md5_checksum": "99e1b247eac7605c93d40a6ab5338889",
     "data_object_type": "TRNA Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_trna.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -127,7 +127,7 @@
     "file_size_bytes": 32946997657,
     "md5_checksum": "daf097448aa3cc77e4857db08a394316",
     "data_object_type": "Metagenome Raw Reads",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmsa-11-12zphj81.1/52818.1.460070.CCAAGTTG-CCAAGTTG.fastq.gz",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "instrument_data"
     },
@@ -138,7 +138,7 @@
     "file_size_bytes": 1050063812,
     "md5_checksum": "e1c5c5f4cb51ac3454e32d00defd11f2",
     "data_object_type": "Clusters of Orthologous Groups (COG) Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_cog.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -149,7 +149,7 @@
     "file_size_bytes": 425,
     "md5_checksum": "21a3dd34fc0d5c23b3f37245f42691cb",
     "data_object_type": "Annotation Info File",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_imgap.info",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -160,7 +160,7 @@
     "file_size_bytes": 845106,
     "md5_checksum": "01eb372cd79339576c48171983953c35",
     "data_object_type": "CRT Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_crt.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -171,7 +171,7 @@
     "file_size_bytes": 990106690,
     "md5_checksum": "f5f47fc817db9862576245623676266e",
     "data_object_type": "Pfam Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_pfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -182,7 +182,7 @@
     "file_size_bytes": 1279173821,
     "md5_checksum": "cbd2ebcf6d765d7107ecd94f7540562d",
     "data_object_type": "Structural Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_structural_annotation.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -193,7 +193,7 @@
     "file_size_bytes": 1219908954,
     "md5_checksum": "17aeeb8e054ce065720cbb4e85223362",
     "data_object_type": "SUPERFam Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_supfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -204,7 +204,7 @@
     "file_size_bytes": 784025535,
     "md5_checksum": "3eebf301f22bf309bc39971d2a92d70a",
     "data_object_type": "KO_EC Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_ko_ec.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -215,7 +215,7 @@
     "file_size_bytes": 168512741,
     "md5_checksum": "5cca7ba622e06217d88e2b03a38c8617",
     "data_object_type": "Annotation Enzyme Commission",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_ec.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -226,7 +226,7 @@
     "file_size_bytes": 118472167,
     "md5_checksum": "7cc6957f9f6f0578ce14ef0ce7ec2880",
     "data_object_type": "TIGRFam Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_tigrfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -237,7 +237,7 @@
     "file_size_bytes": 1027812532,
     "md5_checksum": "5e97832686784ab995d436549803f713",
     "data_object_type": "CATH FunFams (Functional Families) Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_cath_funfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -248,7 +248,7 @@
     "file_size_bytes": 2083494972,
     "md5_checksum": "935b5ded5e33eaf9d99f4f4afeb026d2",
     "data_object_type": "Functional Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_functional_annotation.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -259,7 +259,7 @@
     "file_size_bytes": 54748,
     "md5_checksum": "f24c3e2e45e1ac9bcff70a73701251b0",
     "data_object_type": "Annotation Statistics",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_stats.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -270,7 +270,7 @@
     "file_size_bytes": 29723656027,
     "md5_checksum": "5940b5da7c0c7bc662ed755f2dd97682",
     "data_object_type": "Assembly Coverage BAM",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgas-11-fw6wxd21.1/nmdc_wfmgas-11-fw6wxd21.1_pairedMapped_sorted.sam.gz",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -281,7 +281,7 @@
     "file_size_bytes": 1027812532,
     "md5_checksum": "003012c98f16596002571b3e10d82437",
     "data_object_type": "CATH FunFams (Functional Families) Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_cath_funfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -292,7 +292,7 @@
     "file_size_bytes": 5119846,
     "md5_checksum": "81085fac02763cd7b16ab0cd1db13efb",
     "data_object_type": "RFAM Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_rfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -303,7 +303,7 @@
     "file_size_bytes": 1124066215,
     "md5_checksum": "68eed51716ffd37beb0a9b642871b9ee",
     "data_object_type": "Genemark Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_genemark.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -314,7 +314,7 @@
     "file_size_bytes": 644109302,
     "md5_checksum": "de669a34f6168bb11ecff43b597ab4c5",
     "data_object_type": "Product Names",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_product_names.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -325,7 +325,7 @@
     "file_size_bytes": 11983,
     "md5_checksum": "d0d556520bef909ee606ffb497870522",
     "data_object_type": "GOTTCHA2 Classification Report",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfrbt-11-y0bq8j10.1/nmdc_wfrbt-11-y0bq8j10.1_gottcha2_report.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -336,7 +336,7 @@
     "file_size_bytes": 271413,
     "md5_checksum": "2ed13fe45487cb950da4cdfad1485f41",
     "data_object_type": "Centrifuge output report file",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfrbt-11-y0bq8j10.1/nmdc_wfrbt-11-y0bq8j10.1_centrifuge_report.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -347,7 +347,7 @@
     "file_size_bytes": 990106690,
     "md5_checksum": "f468aee19c9349b8e1d0f2ad824eb1c4",
     "data_object_type": "Pfam Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_pfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -358,7 +358,7 @@
     "file_size_bytes": 252988267,
     "md5_checksum": "03f87806d976094c701fbb8d803b85c9",
     "data_object_type": "Annotation KEGG Orthology",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_ko.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -369,7 +369,7 @@
     "file_size_bytes": 32369646951,
     "md5_checksum": "aa36fa8037ed0c5af3e59dde5ffa6eb3",
     "data_object_type": "Centrifuge Taxonomic Classification",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfrbt-11-y0bq8j10.1/nmdc_wfrbt-11-y0bq8j10.1_centrifuge_classification.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -380,7 +380,7 @@
     "file_size_bytes": 784025535,
     "md5_checksum": "eaf71440091f6931b6bc4227f885556f",
     "data_object_type": "KO_EC Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_ko_ec.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -391,7 +391,7 @@
     "file_size_bytes": 54748,
     "md5_checksum": "6d656797dc05575e24b151da9fd4b1fe",
     "data_object_type": "Annotation Statistics",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_stats.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -402,7 +402,7 @@
     "file_size_bytes": 1122116371,
     "md5_checksum": "e5fc8129663890e4eb01545734ffc0fc",
     "data_object_type": "Gene Phylogeny tsv",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_gene_phylogeny.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -413,7 +413,7 @@
     "file_size_bytes": 2281038803,
     "md5_checksum": "d913236778814eb39276b75561c973f8",
     "data_object_type": "Prodigal Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_prodigal.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -424,7 +424,7 @@
     "file_size_bytes": 4075795,
     "md5_checksum": "0028b04ba576d7d4db6a1c245ed6cd49",
     "data_object_type": "Kraken2 Krona Plot",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfrbt-11-y0bq8j10.1/nmdc_wfrbt-11-y0bq8j10.1_kraken2_krona.html",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -435,7 +435,7 @@
     "file_size_bytes": 374139,
     "md5_checksum": "a34bb4be32a05e7a1f854d8b4a8b5962",
     "data_object_type": "Crispr Terms",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_crt.crisprs",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -446,7 +446,7 @@
     "file_size_bytes": 845106,
     "md5_checksum": "6ebf396577d375d4a74a37402294a650",
     "data_object_type": "CRT Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_crt.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -457,7 +457,7 @@
     "file_size_bytes": 1122116371,
     "md5_checksum": "190ba408b03ccaad99781fce69149d20",
     "data_object_type": "Gene Phylogeny tsv",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_gene_phylogeny.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -468,7 +468,7 @@
     "file_size_bytes": 267035,
     "md5_checksum": "de1b79665e83c754cdf6b7c3650d2ad6",
     "data_object_type": "GOTTCHA2 Krona Plot",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfrbt-11-y0bq8j10.1/nmdc_wfrbt-11-y0bq8j10.1_gottcha2_krona.html",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -479,7 +479,7 @@
     "file_size_bytes": 3876564670, 
     "md5_checksum": "4b52c82f83b86265a1dde6901d2116b8",
     "data_object_type": "Assembly Contigs",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgas-11-fw6wxd21.1/nmdc_wfmgas-11-fw6wxd21.1_contigs.fna",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -490,7 +490,7 @@
     "file_size_bytes": 2392191,
     "md5_checksum": "ac61c9dfc8a9520e9939cae821cdadd9",
     "data_object_type": "Centrifuge Krona Plot",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfrbt-11-y0bq8j10.1/nmdc_wfrbt-11-y0bq8j10.1_centrifuge_krona.html",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -501,7 +501,7 @@
     "file_size_bytes": 2281038803, 
     "md5_checksum": "cd7705e1358b0d74f4657f58b60fe330",
     "data_object_type": "Prodigal Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_prodigal.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -512,7 +512,7 @@
     "file_size_bytes": 1279173821,
     "md5_checksum": "c03197e1db66b88c329d05bcee48c85b",
     "data_object_type": "Structural Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_structural_annotation.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -523,7 +523,7 @@
     "file_size_bytes": 1532669,
     "md5_checksum": "fd5a3f5ac840c0c12c72038010777515",
     "data_object_type": "GOTTCHA2 Report Full",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfrbt-11-y0bq8j10.1/nmdc_wfrbt-11-y0bq8j10.1_gottcha2_full_tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -534,7 +534,7 @@
     "file_size_bytes": 118472167,
     "md5_checksum": "ab227dda8aed5b3d80831867833e3809",
     "data_object_type": "TIGRFam Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_tigrfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -545,7 +545,7 @@
     "file_size_bytes": 250050777,
     "md5_checksum": "298edd833500633cd68acf74941afbd6",
     "data_object_type": "SMART Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_smart.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -556,7 +556,7 @@
     "file_size_bytes": 2081405691,
     "md5_checksum": "63bfb347a0abc3bac2114a45c6f7c864",
     "data_object_type": "Functional Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_functional_annotation.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -567,7 +567,7 @@
     "file_size_bytes": 646198583,
     "md5_checksum": "48afdc3f6a339128dd201384f5ae5fc8",
     "data_object_type": "Product Names",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_product_names.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -578,7 +578,7 @@
     "file_size_bytes": 3740,
     "md5_checksum": "d4fc96d0ff5174ec4260be6dc5dc2f8c",
     "data_object_type": "QC Statistics",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfrqc-11-mqkh9j68.1/nmdc_wfrqc-11-mqkh9j68.1_filterStats.txt",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -589,7 +589,7 @@
     "file_size_bytes": 26373317716, 
     "md5_checksum": "1111b95528de6a1d69f137fce962bb68",
     "data_object_type": "Kraken2 Taxonomic Classification",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfrbt-11-y0bq8j10.1/nmdc_wfrbt-11-y0bq8j10.1_kraken2_classification.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -600,7 +600,7 @@
     "file_size_bytes": 648132972,
     "md5_checksum": "9c8df218a5d1f71a0b0dc45164bc72f2",
     "data_object_type": "Scaffold Lineage tsv",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_scaffold_lineage.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -611,7 +611,7 @@
     "file_size_bytes": 1846167706,
     "md5_checksum": "ad636e89e472745149ecbb3f5211e932",
     "data_object_type": "Annotation Amino Acid FASTA",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_proteins.faa",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -622,7 +622,7 @@
     "file_size_bytes": 27762746219,
     "md5_checksum": "5438aee7248c897ed9c28aab540600a2",
     "data_object_type": "Filtered Sequencing Reads",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfrqc-11-mqkh9j68.1/nmdc_wfrqc-11-mqkh9j68.1_filtered.fastq.gz",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -633,7 +633,7 @@
     "file_size_bytes": 168512741,
     "md5_checksum": "2f115a7200966a9b5e27a7ec5515aaab",
     "data_object_type": "Annotation Enzyme Commission",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_ec.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -644,7 +644,7 @@
     "file_size_bytes": 339440804,
     "md5_checksum": "16488643c0746ecfab437a486f9ec827",
     "data_object_type": "Assembly Coverage Stats",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgas-11-fw6wxd21.1/nmdc_wfmgas-11-fw6wxd21.1_covstats.txt",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -655,7 +655,7 @@
     "file_size_bytes": 252988267,
     "md5_checksum": "9f873346e2a52943c667de6a66742ec1",
     "data_object_type": "Annotation KEGG Orthology",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.1/nmdc_wfmgan-11-kxtjhj81.1_ko.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -666,7 +666,7 @@
     "file_size_bytes": 5119846,
     "md5_checksum": "dcc4ba1c85f8da3fbbc4af35a46c3d44",
     "data_object_type": "RFAM Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_rfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -677,7 +677,7 @@
     "file_size_bytes": 664823,
     "md5_checksum": "3fb480bc289b5908f081d630fc25b22d",
     "data_object_type": "Kraken2 Classification Report",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfrbt-11-y0bq8j10.1/nmdc_wfrbt-11-y0bq8j10.1_kraken2_report.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -688,7 +688,7 @@
     "file_size_bytes": 5055913,
     "md5_checksum": "6ba0419218fc9e4e8ed380ca3cf8f331",
     "data_object_type": "TRNA Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-bm72c549/nmdc:wfmgan-11-kxtjhj81.2/nmdc_wfmgan-11-kxtjhj81.2_trna.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -699,7 +699,7 @@
     "file_size_bytes": 3316917053,
     "md5_checksum": "cb4fd6e3f5396b209ec9e67fecaae6a4",
     "data_object_type": "Assembly Contigs",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_contigs.fna",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -710,7 +710,7 @@
     "file_size_bytes": 1197387021,
     "md5_checksum": "24942c38da4278daae12ac9192c25745",
     "data_object_type": "SUPERFam Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_supfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -721,7 +721,7 @@
     "file_size_bytes": 5000827,
     "md5_checksum": "037db5f69c0428108f29b3e3e15872de",
     "data_object_type": "RFAM Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_rfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -732,7 +732,7 @@
     "file_size_bytes": 28024829432,
     "md5_checksum": "e113794244a1614c4165c2abb4f118d1",
     "data_object_type": "Centrifuge Taxonomic Classification",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfrbt-11-5zc5jn42.1/nmdc_wfrbt-11-5zc5jn42.1_centrifuge_classification.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -743,7 +743,7 @@
     "file_size_bytes": 27412668393,
     "md5_checksum": "aa28ce2e1191115466c2a4775f78c6bb",
     "data_object_type": "Metagenome Raw Reads",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmsa-11-jv88pn76.1/52818.3.460102.TCTCGCAA-TCTCGCAA.fastq.gz",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "instrument_data"
     },
@@ -754,7 +754,7 @@
     "file_size_bytes": 214095788,
     "md5_checksum": "4635df426db6915ff717e78c25c2db2e",
     "data_object_type": "SMART Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_smart.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -765,7 +765,7 @@
     "file_size_bytes": 311552,
     "md5_checksum": "d0a47a17c4c19c714670a9027dd3db26",
     "data_object_type": "Crispr Terms",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_crt.crisprs",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -776,7 +776,7 @@
     "file_size_bytes": 651371,
     "md5_checksum": "a2b7f4fef371e3034309bb11ccf64a4e",
     "data_object_type": "CRT Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_crt.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -787,7 +787,7 @@
     "file_size_bytes": 1083628447,
     "md5_checksum": "99f0992dbc2e7f678af941bd21c53a90",
     "data_object_type": "Clusters of Orthologous Groups (COG) Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_cog.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -798,7 +798,7 @@
     "file_size_bytes": 16709,
     "md5_checksum": "e70ae2b140f24e5088ac0856a785e6aa",
     "data_object_type": "GOTTCHA2 Classification Report",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfrbt-11-5zc5jn42.1/nmdc_wfrbt-11-5zc5jn42.1_gottcha2_report.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -809,7 +809,7 @@
     "file_size_bytes": 4151,
     "md5_checksum": "964bc10522ecc6c8f6e3472836e7aa0b",
     "data_object_type": "Assembly Info File",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgas-11-q03x3q96.1/nmdc_wfmgas-11-q03x3q96.1_metaAsm.info",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -820,7 +820,7 @@
     "file_size_bytes": 217663107,
     "md5_checksum": "432d079833c851e71718ba4a2235fbdc",
     "data_object_type": "SMART Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_smart.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -831,7 +831,7 @@
     "file_size_bytes": 3240103455,
     "md5_checksum": "ec9c3150992fc36aea61744cd9d1da07",
     "data_object_type": "Assembly Contigs",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgas-11-q03x3q96.1/nmdc_wfmgas-11-q03x3q96.1_contigs.fna",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -842,7 +842,7 @@
     "file_size_bytes": 657934,
     "md5_checksum": "9e2f274e007f47977b54468e1058784b",
     "data_object_type": "Kraken2 Classification Report",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfrbt-11-5zc5jn42.1/nmdc_wfrbt-11-5zc5jn42.1_kraken2_report.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -853,7 +853,7 @@
     "file_size_bytes": 977991175,
     "md5_checksum": "eac3f3e3c061acf351247cbec2bf42f0",
     "data_object_type": "CATH FunFams (Functional Families) Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_cath_funfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -864,7 +864,7 @@
     "file_size_bytes": 1105836864,
     "md5_checksum": "8b0eb15ff85938f2f54444bd4044eac4",
     "data_object_type": "Genemark Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_genemark.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -875,7 +875,7 @@
     "file_size_bytes": 1103390722,
     "md5_checksum": "919d44b3acc82cd0fb7e9e5df118df14",
     "data_object_type": "Clusters of Orthologous Groups (COG) Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_cog.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -886,7 +886,7 @@
     "file_size_bytes": 1687865819,
     "md5_checksum": "e7cc354795d3bed9ace0e3e43ec16bda",
     "data_object_type": "Annotation Amino Acid FASTA",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_proteins.faa",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -897,7 +897,7 @@
     "file_size_bytes": 2089060026,
     "md5_checksum": "8f713a22dea0e9cbd463c4c8017423ee",
     "data_object_type": "Functional Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_functional_annotation.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -908,7 +908,7 @@
     "file_size_bytes": 1217125930,
     "md5_checksum": "67dc1c79f345c54e5319c3af30a18243",
     "data_object_type": "SUPERFam Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_supfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -919,7 +919,7 @@
     "file_size_bytes": 771482393,
     "md5_checksum": "8a6a3d2371c494a2c5d7ee0c13c0c50f",
     "data_object_type": "Scaffold Lineage tsv",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_scaffold_lineage.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -930,7 +930,7 @@
     "file_size_bytes": 4437061,
     "md5_checksum": "efc2768b4adc140c9aa8a250161175d6",
     "data_object_type": "TRNA Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_trna.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -941,7 +941,7 @@
     "file_size_bytes": 812082559,
     "md5_checksum": "1c9b0afd4e120d2d0f7ffcd684d0d2ef",
     "data_object_type": "KO_EC Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_ko_ec.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -952,7 +952,7 @@
     "file_size_bytes": 279678,
     "md5_checksum": "bcb28d03cc98a5ce1fb4f946a8a64333",
     "data_object_type": "GOTTCHA2 Krona Plot",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfrbt-11-5zc5jn42.1/nmdc_wfrbt-11-5zc5jn42.1_gottcha2_krona.html",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -963,7 +963,7 @@
     "file_size_bytes": 23787965684,
     "md5_checksum": "4311f3a048190f87e260ee3c9e7065c9",
     "data_object_type": "Filtered Sequencing Reads",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfrqc-11-710c6609.1/nmdc_wfrqc-11-710c6609.1_filtered.fastq.gz",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -974,7 +974,7 @@
     "file_size_bytes": 425,
     "md5_checksum": "21a3dd34fc0d5c23b3f37245f42691cb",
     "data_object_type": "Annotation Info File",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_imgap.info",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -985,7 +985,7 @@
     "file_size_bytes": 677313,
     "md5_checksum": "e4a70f179c96e4f5e23cfedd622094d0",
     "data_object_type": "CRT Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_crt.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -996,7 +996,7 @@
     "file_size_bytes": 176360134,
     "md5_checksum": "1c3e75c5f95d4aa9f14fa90319eafb93",
     "data_object_type": "Annotation Enzyme Commission",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_ec.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1007,7 +1007,7 @@
     "file_size_bytes": 936124413,
     "md5_checksum": "7302389dd9d8494c1fa4cace0badccc5",
     "data_object_type": "Pfam Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_pfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1018,7 +1018,7 @@
     "file_size_bytes": 643614041,
     "md5_checksum": "2a593c3a45b1ba3712387f6b92588452",
     "data_object_type": "Product Names",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_product_names.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1029,7 +1029,7 @@
     "file_size_bytes": 1706871987,
     "md5_checksum": "b3660aa3901fd473673e7c4171c6324a",
     "data_object_type": "Annotation Amino Acid FASTA",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_proteins.faa",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1040,7 +1040,7 @@
     "file_size_bytes": 3740,
     "md5_checksum": "f2ef527c06fa483317da8c0d0ce588b3",
     "data_object_type": "QC Statistics",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfrqc-11-710c6609.1/nmdc_wfrqc-11-710c6609.1_filterStats.txt",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1051,7 +1051,7 @@
     "file_size_bytes": 99293273,
     "md5_checksum": "35cc6f4759cb20d15a373c780485a351",
     "data_object_type": "TIGRFam Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_tigrfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1062,7 +1062,7 @@
     "file_size_bytes": 23282532683,
     "md5_checksum": "97ae5e6aeba4007def847282fe537920",
     "data_object_type": "Kraken2 Taxonomic Classification",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfrbt-11-5zc5jn42.1/nmdc_wfrbt-11-5zc5jn42.1_kraken2_classification.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1073,7 +1073,7 @@
     "file_size_bytes": 4049993,
     "md5_checksum": "12bcb3a4cda31122dc398cb841841a8e",
     "data_object_type": "Kraken2 Krona Plot",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfrbt-11-5zc5jn42.1/nmdc_wfrbt-11-5zc5jn42.1_kraken2_krona.html",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1084,7 +1084,7 @@
     "file_size_bytes": 4907001,
     "md5_checksum": "cd5f7d6c9255682ccf7d62f7100204ca",
     "data_object_type": "RFAM Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_rfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1095,7 +1095,7 @@
     "file_size_bytes": 470,
     "md5_checksum": "2854a85740fdd20dd61bbe5c9897cc24",
     "data_object_type": "Annotation Info File",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_imgap.info",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1106,7 +1106,7 @@
     "file_size_bytes": 2913,
     "md5_checksum": "7b6e8a5ce66b83ec5880f0016989c8a4",
     "data_object_type": "Annotation Statistics",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_stats.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1117,7 +1117,7 @@
     "file_size_bytes": 1164047208,
     "md5_checksum": "d22231a15460b6e81c82848e147001bf",
     "data_object_type": "Gene Phylogeny tsv",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_gene_phylogeny.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1128,7 +1128,7 @@
     "file_size_bytes": 2380140088,
     "md5_checksum": "fe09125ef410f01c1eb61ba1fd98adb5",
     "data_object_type": "Prodigal Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_prodigal.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1139,7 +1139,7 @@
     "file_size_bytes": 271453,
     "md5_checksum": "afc860e4ad8d294ed1b2f7308d4d0669",
     "data_object_type": "Centrifuge output report file",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfrbt-11-5zc5jn42.1/nmdc_wfrbt-11-5zc5jn42.1_centrifuge_report.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1150,7 +1150,7 @@
     "file_size_bytes": 1525734,
     "md5_checksum": "6a701960d486b0e2165f86056d7d08d0",
     "data_object_type": "GOTTCHA2 Report Full",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfrbt-11-5zc5jn42.1/nmdc_wfrbt-11-5zc5jn42.1_gottcha2_full_tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1161,7 +1161,7 @@
     "file_size_bytes": 954959382,
     "md5_checksum": "9cab84dab0691a0c5305f3d393a5eb49",
     "data_object_type": "Pfam Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_pfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1172,7 +1172,7 @@
     "file_size_bytes": 171776486,
     "md5_checksum": "53ed8e60ff7ed12353b2010eaff743d4",
     "data_object_type": "Annotation Enzyme Commission",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_ec.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1183,7 +1183,7 @@
     "file_size_bytes": 626809299,
     "md5_checksum": "57734135f4ec00910968bf1b633c1bbf",
     "data_object_type": "Product Names",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_product_names.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1194,7 +1194,7 @@
     "file_size_bytes": 2053108867,
     "md5_checksum": "334352e3cd2740e1fc7c8f669332f750",
     "data_object_type": "Functional Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_functional_annotation.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1205,7 +1205,7 @@
     "file_size_bytes": 1177970039,
     "md5_checksum": "9541e6924eafeb1f94dd60ca417603d0",
     "data_object_type": "Gene Phylogeny tsv",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_gene_phylogeny.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1216,7 +1216,7 @@
     "file_size_bytes": 2912,
     "md5_checksum": "5515c599ba84d0e2ce14a0d5740d3a56",
     "data_object_type": "Annotation Statistics",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_stats.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1227,7 +1227,7 @@
     "file_size_bytes": 2431585811,
     "md5_checksum": "75f6c993c5dd1a76a435e3cf14394fe4",
     "data_object_type": "Prodigal Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_prodigal.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1238,7 +1238,7 @@
     "file_size_bytes": 26211920983,
     "md5_checksum": "0658cbe736a6c00845ca6938f179632d",
     "data_object_type": "Assembly Coverage BAM",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgas-11-q03x3q96.1/nmdc_wfmgas-11-q03x3q96.1_pairedMapped_sorted.sam.gz",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1249,7 +1249,7 @@
     "file_size_bytes": 299,
     "md5_checksum": "278a0b41e1a566f445b60268b5569829",
     "data_object_type": "Read Based Analysis Info File",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfrbt-11-5zc5jn42.1/nmdc_wfrbt-11-5zc5jn42.1_profiler.info",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1260,7 +1260,7 @@
     "file_size_bytes": 379819706,
     "md5_checksum": "455da1670882b13015f7f9718d21c7da",
     "data_object_type": "Assembly Coverage Stats",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgas-11-q03x3q96.1/nmdc_wfmgas-11-q03x3q96.1_covstats.txt",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1271,7 +1271,7 @@
     "file_size_bytes": 2391186,
     "md5_checksum": "2cc56c0c34a22d0a8d8e636d668b7d8b",
     "data_object_type": "Centrifuge Krona Plot",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfrbt-11-5zc5jn42.1/nmdc_wfrbt-11-5zc5jn42.1_centrifuge_krona.html",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1282,7 +1282,7 @@
     "file_size_bytes": 993340521,
     "md5_checksum": "911be12038db6cb1b2aab70f3e152294",
     "data_object_type": "CATH FunFams (Functional Families) Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_cath_funfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1293,7 +1293,7 @@
     "file_size_bytes": 4545319,
     "md5_checksum": "6806ebaa9f97a378d8dd88918f005c63",
     "data_object_type": "TRNA Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_trna.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1304,7 +1304,7 @@
     "file_size_bytes": 97156189,
     "md5_checksum": "f1548fa790784aa7d9290918e48657ef",
     "data_object_type": "TIGRFam Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_tigrfam.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1315,7 +1315,7 @@
     "file_size_bytes": 258976511,
     "md5_checksum": "14c829b52d7c399e64833a51337198f0",
     "data_object_type": "Annotation KEGG Orthology",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_ko.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1326,7 +1326,7 @@
     "file_size_bytes": 1277284780,
     "md5_checksum": "66a34dff8e48b951513b30a8912ea427",
     "data_object_type": "Structural Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_structural_annotation.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1337,7 +1337,7 @@
     "file_size_bytes": 290705526,
     "md5_checksum": "47f08484d1eb049a96b19db16fc390ea",
     "data_object_type": "Contig Mapping File",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_contig_names_mapping.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1348,7 +1348,7 @@
     "file_size_bytes": 265963604,
     "md5_checksum": "6c941e98d497644f6344d10ba71ecd3f",
     "data_object_type": "Annotation KEGG Orthology",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_ko.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1359,7 +1359,7 @@
     "file_size_bytes": 1239053541,
     "md5_checksum": "a7ee0a40fe75fb0f7cca80b107958219",
     "data_object_type": "Structural Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_structural_annotation.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1370,7 +1370,7 @@
     "file_size_bytes": 826056431,
     "md5_checksum": "2d380f65f8f012a98c89c25e8f5b0dfd",
     "data_object_type": "KO_EC Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_ko_ec.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1381,7 +1381,7 @@
     "file_size_bytes": 1143238538,
     "md5_checksum": "6b50ab061042b670b04527843aaae87f",
     "data_object_type": "Genemark Annotation GFF",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_genemark.gff",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1392,7 +1392,7 @@
     "file_size_bytes": 783618562,
     "md5_checksum": "104aff57086731e5ed51bcae09db3a95",
     "data_object_type": "Scaffold Lineage tsv",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.1/nmdc_wfmgan-11-zsea1s60.1_scaffold_lineage.tsv",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     },
@@ -1403,7 +1403,7 @@
     "file_size_bytes": 304058,
     "md5_checksum": "1326e5c71fec6d77da422c98522b9b44",
     "data_object_type": "Crispr Terms",
-    "url": "https://data.microbiomedata.org/data/nmdc:omprc-11-tvg68444/nmdc:wfmgan-11-zsea1s60.2/nmdc_wfmgan-11-zsea1s60.2_crt.crisprs",
+    "url": "https://data.microbiomedata.org",
     "type": "nmdc:DataObject",
     "data_category": "processed_data"
     }

--- a/tests/fixtures/nmdc_db/job_manifest_update_indiv_done.json
+++ b/tests/fixtures/nmdc_db/job_manifest_update_indiv_done.json
@@ -1,0 +1,942 @@
+[{
+  "workflow": {
+    "id": "Reads QC Interleave: v1.0.16"
+  },
+  "id": "nmdc:70ab9ac8-207d-11f0-9bba-bebac50d2d4e",
+  "created_at": {
+    "$date": "2025-04-23T19:59:18.000Z"
+  },
+  "config": {
+    "git_repo": "https://github.com/microbiomedata/ReadsQC",
+    "release": "v1.0.16",
+    "wdl": "interleave_rqcfilter.wdl",
+    "activity_id": "nmdc:wfrqc-11-barp9t72.1",
+    "activity_set": "workflow_execution_set",
+    "was_informed_by": [
+      "nmdc:dgns-11-syr2vn62"
+    ],
+    "trigger_activity": "nmdc:dgns-11-syr2vn62",
+    "iteration": 1,
+    "input_prefix": "nmdc_rqcfilter",
+    "inputs": {
+      "proj": "nmdc:wfrqc-11-barp9t72.1",
+      "input_fastq1": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM5BGX7_srt_R1/BMI_HFWM5BGX7_Plate68WellC3_srt_R1.fastq.gz",
+      "input_fastq2": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM5BGX7_srt_R2/BMI_HFWM5BGX7_Plate68WellC3_srt_R2.fastq.gz"
+    },
+    "input_data_objects": [
+      {
+        "id": "nmdc:dobj-11-kpt53f77",
+        "type": "nmdc:DataObject",
+        "name": "BMI_HFWM5BGX7_Plate68WellC3_srt_R1.fastq.gz",
+        "description": "sequencing results for BMI_HFWM5BGX7_Plate68WellC3_srt_R1",
+        "data_object_type": "Metagenome Raw Read 1",
+        "md5_checksum": "0c8cd298c47550bb18e320ab380d2ddc",
+        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM5BGX7_srt_R1/BMI_HFWM5BGX7_Plate68WellC3_srt_R1.fastq.gz"
+      },
+      {
+        "id": "nmdc:dobj-11-tv9g1670",
+        "type": "nmdc:DataObject",
+        "name": "BMI_HFWM5BGX7_Plate68WellC3_srt_R2.fastq.gz",
+        "description": "sequencing results for BMI_HFWM5BGX7_Plate68WellC3_srt_R2",
+        "data_object_type": "Metagenome Raw Read 2",
+        "md5_checksum": "2ecf576a571a4cd0b6b9a92261a2c720",
+        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM5BGX7_srt_R2/BMI_HFWM5BGX7_Plate68WellC3_srt_R2.fastq.gz"
+      }
+    ],
+    "activity": {
+      "name": "Read QC for {id}",
+      "input_read_bases": "{outputs.stats.input_read_bases}",
+      "input_read_count": "{outputs.stats.input_read_count}",
+      "output_read_bases": "{outputs.stats.output_read_bases}",
+      "output_read_count": "{outputs.stats.output_read_count}",
+      "type": "nmdc:ReadQcAnalysis"
+    },
+    "outputs": [
+      {
+        "output": "filtered_final",
+        "name": "Reads QC result fastq (clean data)",
+        "data_object_type": "Filtered Sequencing Reads",
+        "description": "Reads QC for {id}",
+        "id": "nmdc:dobj-11-4azk9x12"
+      },
+      {
+        "output": "filtered_stats_final",
+        "name": "Reads QC summary statistics",
+        "data_object_type": "QC Statistics",
+        "description": "Reads QC summary for {id}",
+        "id": "nmdc:dobj-11-ke2q9b04"
+      },
+      {
+        "output": "rqc_info",
+        "name": "File containing read filtering information",
+        "data_object_type": "Read Filtering Info File",
+        "description": "Read filtering info for {id}",
+        "id": "nmdc:dobj-11-yg55xz65"
+      }
+    ]
+  },
+  "claims": []
+},
+{
+  "workflow": {
+    "id": "Reads QC Interleave: v1.0.18"
+  },
+  "id": "nmdc:9a8caa7e-29d5-11f0-a6b6-6e3122654c51",
+  "created_at": {
+    "$date": "2025-05-05T17:23:04.000Z"
+  },
+  "config": {
+    "git_repo": "https://github.com/microbiomedata/ReadsQC",
+    "release": "v1.0.18",
+    "wdl": "interleave_rqcfilter.wdl",
+    "activity_id": "nmdc:wfrqc-11-2rg3xg37.1",
+    "activity_set": "workflow_execution_set",
+    "was_informed_by": [
+      "nmdc:dgns-11-syr2vn62"
+    ],
+    "trigger_activity": "nmdc:dgns-11-syr2vn62",
+    "iteration": 1,
+    "input_prefix": "nmdc_rqcfilter",
+    "inputs": {
+      "proj": "nmdc:wfrqc-11-2rg3xg37.1",
+      "input_fastq1": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM5BGX7_srt_R1/BMI_HFWM5BGX7_Plate68WellC3_srt_R1.fastq.gz",
+      "input_fastq2": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM5BGX7_srt_R2/BMI_HFWM5BGX7_Plate68WellC3_srt_R2.fastq.gz"
+    },
+    "input_data_objects": [
+      {
+        "id": "nmdc:dobj-11-kpt53f77",
+        "type": "nmdc:DataObject",
+        "name": "BMI_HFWM5BGX7_Plate68WellC3_srt_R1.fastq.gz",
+        "description": "sequencing results for BMI_HFWM5BGX7_Plate68WellC3_srt_R1",
+        "data_object_type": "Metagenome Raw Read 1",
+        "md5_checksum": "0c8cd298c47550bb18e320ab380d2ddc",
+        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM5BGX7_srt_R1/BMI_HFWM5BGX7_Plate68WellC3_srt_R1.fastq.gz"
+      },
+      {
+        "id": "nmdc:dobj-11-tv9g1670",
+        "type": "nmdc:DataObject",
+        "name": "BMI_HFWM5BGX7_Plate68WellC3_srt_R2.fastq.gz",
+        "description": "sequencing results for BMI_HFWM5BGX7_Plate68WellC3_srt_R2",
+        "data_object_type": "Metagenome Raw Read 2",
+        "md5_checksum": "2ecf576a571a4cd0b6b9a92261a2c720",
+        "url": "https://storage.neonscience.org/neon-microbial-raw-seq-files/2023/BMI_HFWM5BGX7_srt_R2/BMI_HFWM5BGX7_Plate68WellC3_srt_R2.fastq.gz"
+      }
+    ],
+    "activity": {
+      "name": "Read QC for {id}",
+      "input_read_bases": "{outputs.stats.input_read_bases}",
+      "input_read_count": "{outputs.stats.input_read_count}",
+      "output_read_bases": "{outputs.stats.output_read_bases}",
+      "output_read_count": "{outputs.stats.output_read_count}",
+      "type": "nmdc:ReadQcAnalysis"
+    },
+    "outputs": [
+      {
+        "output": "filtered_final",
+        "name": "Reads QC result fastq (clean data)",
+        "data_object_type": "Filtered Sequencing Reads",
+        "description": "Reads QC for {id}",
+        "id": "nmdc:dobj-11-r1dngr87"
+      },
+      {
+        "output": "filtered_stats_final",
+        "name": "Reads QC summary statistics",
+        "data_object_type": "QC Statistics",
+        "description": "Reads QC summary for {id}",
+        "id": "nmdc:dobj-11-dpb8yd39"
+      },
+      {
+        "output": "rqc_info",
+        "name": "File containing read filtering information",
+        "data_object_type": "Read Filtering Info File",
+        "description": "Read filtering info for {id}",
+        "id": "nmdc:dobj-11-j5xkvb53"
+      }
+    ]
+  },
+  "claims": [
+    {
+      "op_id": "nmdc:sys0kng6x240",
+      "site_id": "NERSC"
+    }
+  ]
+},
+{
+  "workflow": {
+    "id": "Readbased Analysis: v1.0.10"
+  },
+  "id": "nmdc:22d55d68-2ada-11f0-8bae-6e3122654c51",
+  "created_at": {
+    "$date": "2025-05-07T00:28:02.000Z"
+  },
+  "config": {
+    "git_repo": "https://github.com/microbiomedata/ReadbasedAnalysis",
+    "release": "v1.0.10",
+    "wdl": "ReadbasedAnalysis.wdl",
+    "activity_id": "nmdc:wfrbt-11-vtvzgn61.1",
+    "activity_set": "workflow_execution_set",
+    "was_informed_by": [
+      "nmdc:dgns-11-syr2vn62"
+    ],
+    "trigger_activity": "nmdc:wfrqc-11-2rg3xg37.1",
+    "iteration": 1,
+    "input_prefix": "ReadbasedAnalysis",
+    "inputs": {
+      "input_file": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfrqc-11-2rg3xg37.1/nmdc_wfrqc-11-2rg3xg37.1_filtered.fastq.gz",
+      "proj": "nmdc:wfrbt-11-vtvzgn61.1"
+    },
+    "input_data_objects": [
+      {
+        "id": "nmdc:dobj-11-r1dngr87",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfrqc-11-2rg3xg37.1_filtered.fastq.gz",
+        "description": "Reads QC for nmdc:wfrqc-11-2rg3xg37.1",
+        "data_category": "processed_data",
+        "data_object_type": "Filtered Sequencing Reads",
+        "file_size_bytes": 224596346,
+        "md5_checksum": "1b98dbead8b2d8515ede70023f3e563d",
+        "url": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfrqc-11-2rg3xg37.1/nmdc_wfrqc-11-2rg3xg37.1_filtered.fastq.gz",
+        "was_generated_by": "nmdc:wfrqc-11-2rg3xg37.1"
+      }
+    ],
+    "activity": {
+      "name": "Readbased Taxonomy Analysis for {id}",
+      "type": "nmdc:ReadBasedTaxonomyAnalysis"
+    },
+    "outputs": [
+      {
+        "output": "final_gottcha2_report_tsv",
+        "data_object_type": "GOTTCHA2 Classification Report",
+        "description": "GOTTCHA2 Classification for {id}",
+        "name": "GOTTCHA2 classification report file",
+        "id": "nmdc:dobj-11-bc9c6m85"
+      },
+      {
+        "output": "final_gottcha2_full_tsv",
+        "data_object_type": "GOTTCHA2 Report Full",
+        "description": "GOTTCHA2 Full Report for {id}",
+        "name": "GOTTCHA2 report file",
+        "id": "nmdc:dobj-11-6abf6161"
+      },
+      {
+        "output": "final_gottcha2_krona_html",
+        "data_object_type": "GOTTCHA2 Krona Plot",
+        "description": "GOTTCHA2 Krona for {id}",
+        "name": "GOTTCHA2 krona plot HTML file",
+        "id": "nmdc:dobj-11-cf2d2038"
+      },
+      {
+        "output": "final_centrifuge_classification_tsv",
+        "data_object_type": "Centrifuge Taxonomic Classification",
+        "description": "Centrifuge Classification for {id}",
+        "name": "Centrifuge output read classification file",
+        "id": "nmdc:dobj-11-ye059q29"
+      },
+      {
+        "output": "final_centrifuge_report_tsv",
+        "data_object_type": "Centrifuge output report file",
+        "description": "Centrifuge Report for {id}",
+        "name": "Centrifuge Classification Report",
+        "id": "nmdc:dobj-11-w9ygyf87"
+      },
+      {
+        "output": "final_centrifuge_krona_html",
+        "data_object_type": "Centrifuge Krona Plot",
+        "description": "Centrifuge Krona for {id}",
+        "name": "Centrifug krona plot HTML file",
+        "id": "nmdc:dobj-11-gb7hyf30"
+      },
+      {
+        "output": "final_kraken2_classification_tsv",
+        "data_object_type": "Kraken2 Taxonomic Classification",
+        "description": "Kraken2 Classification for {id}",
+        "name": "Kraken2 output read classification file",
+        "id": "nmdc:dobj-11-4vpxrh76"
+      },
+      {
+        "output": "final_kraken2_report_tsv",
+        "data_object_type": "Kraken2 Classification Report",
+        "description": "Kraken2 Report for {id}",
+        "name": "Kraken2 output report file",
+        "id": "nmdc:dobj-11-2e488n81"
+      },
+      {
+        "output": "final_kraken2_krona_html",
+        "data_object_type": "Kraken2 Krona Plot",
+        "description": "Kraken2 Krona for {id}",
+        "name": "Kraken2 Krona plot HTML file",
+        "id": "nmdc:dobj-11-rwrff365"
+      },
+      {
+        "output": "info_file",
+        "data_object_type": "Read Based Analysis Info File",
+        "description": "Read based analysis info for {id}",
+        "name": "File containing reads based analysis information",
+        "suffix": "profiler.info",
+        "id": "nmdc:dobj-11-w0nnqy65"
+      }
+    ]
+  },
+  "claims": [
+    {
+      "op_id": "nmdc:sys0trzrwc25",
+      "site_id": "NERSC"
+    }
+  ]
+},
+{
+  "workflow": {
+    "id": "Metagenome Assembly: v1.0.7-alpha.1"
+  },
+  "id": "nmdc:52f93ac8-2ada-11f0-8bae-6e3122654c51",
+  "created_at": {
+    "$date": "2025-05-07T00:29:23.000Z"
+  },
+  "config": {
+    "git_repo": "https://github.com/microbiomedata/metaAssembly",
+    "release": "v1.0.7-alpha.1",
+    "wdl": "jgi_assembly.wdl",
+    "activity_id": "nmdc:wfmgas-11-83xhja56.1",
+    "activity_set": "workflow_execution_set",
+    "was_informed_by": [
+      "nmdc:dgns-11-syr2vn62"
+    ],
+    "trigger_activity": "nmdc:wfrqc-11-2rg3xg37.1",
+    "iteration": 1,
+    "input_prefix": "jgi_metaAssembly",
+    "inputs": {
+      "input_files": [
+        "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfrqc-11-2rg3xg37.1/nmdc_wfrqc-11-2rg3xg37.1_filtered.fastq.gz"
+      ],
+      "proj": "nmdc:wfmgas-11-83xhja56.1",
+      "shortRead": true
+    },
+    "input_data_objects": [
+      {
+        "id": "nmdc:dobj-11-r1dngr87",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfrqc-11-2rg3xg37.1_filtered.fastq.gz",
+        "description": "Reads QC for nmdc:wfrqc-11-2rg3xg37.1",
+        "data_category": "processed_data",
+        "data_object_type": "Filtered Sequencing Reads",
+        "file_size_bytes": 224596346,
+        "md5_checksum": "1b98dbead8b2d8515ede70023f3e563d",
+        "url": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfrqc-11-2rg3xg37.1/nmdc_wfrqc-11-2rg3xg37.1_filtered.fastq.gz",
+        "was_generated_by": "nmdc:wfrqc-11-2rg3xg37.1"
+      }
+    ],
+    "activity": {
+      "name": "Metagenome Assembly for {id}",
+      "type": "nmdc:MetagenomeAssembly",
+      "asm_score": "{outputs.stats.asm_score}",
+      "contig_bp": "{outputs.stats.contig_bp}",
+      "contigs": "{outputs.stats.contigs}",
+      "ctg_l50": "{outputs.stats.ctg_l50}",
+      "ctg_l90": "{outputs.stats.ctg_l90}",
+      "ctg_logsum": "{outputs.stats.ctg_logsum}",
+      "ctg_max": "{outputs.stats.ctg_max}",
+      "ctg_n50": "{outputs.stats.ctg_n50}",
+      "ctg_n90": "{outputs.stats.ctg_n90}",
+      "ctg_powsum": "{outputs.stats.ctg_powsum}",
+      "gap_pct": "{outputs.stats.gap_pct}",
+      "gc_avg": "{outputs.stats.gc_avg}",
+      "gc_std": "{outputs.stats.gc_std}",
+      "scaf_bp": "{outputs.stats.scaf_bp}",
+      "scaf_l50": "{outputs.stats.scaf_l50}",
+      "scaf_l90": "{outputs.stats.scaf_l90}",
+      "scaf_l_gt50k": "{outputs.stats.scaf_l_gt50k}",
+      "scaf_logsum": "{outputs.stats.scaf_logsum}",
+      "scaf_max": "{outputs.stats.scaf_max}",
+      "scaf_n50": "{outputs.stats.scaf_n50}",
+      "scaf_n90": "{outputs.stats.scaf_n90}",
+      "scaf_n_gt50k": "{outputs.stats.scaf_n_gt50k}",
+      "scaf_pct_gt50k": "{outputs.stats.scaf_pct_gt50k}",
+      "scaf_powsum": "{outputs.stats.scaf_powsum}",
+      "scaffolds": "{outputs.stats.scaffolds}"
+    },
+    "outputs": [
+      {
+        "output": "sr_contig",
+        "name": "Final assembly contigs fasta",
+        "data_object_type": "Assembly Contigs",
+        "description": "Assembly contigs for {id}",
+        "id": "nmdc:dobj-11-a84z9455"
+      },
+      {
+        "output": "sr_scaffold",
+        "name": "Final assembly scaffolds fasta",
+        "data_object_type": "Assembly Scaffolds",
+        "description": "Assembly scaffolds for {id}",
+        "id": "nmdc:dobj-11-yzcj1x82"
+      },
+      {
+        "output": "sr_covstats",
+        "name": "Assembled contigs coverage information",
+        "data_object_type": "Assembly Coverage Stats",
+        "description": "Coverage Stats for {id}",
+        "id": "nmdc:dobj-11-dzra5s97"
+      },
+      {
+        "output": "sr_agp",
+        "name": "An AGP format file that describes the assembly",
+        "data_object_type": "Assembly AGP",
+        "description": "AGP for {id}",
+        "id": "nmdc:dobj-11-e2rw9f71"
+      },
+      {
+        "output": "sr_bam",
+        "name": "Sorted bam file of reads mapping back to the final assembly",
+        "data_object_type": "Assembly Coverage BAM",
+        "description": "Sorted Bam for {id}",
+        "id": "nmdc:dobj-11-23k58474"
+      },
+      {
+        "output": "sr_asminfo",
+        "name": "File containing assembly info",
+        "data_object_type": "Assembly Info File",
+        "description": "Assembly info for {id}",
+        "id": "nmdc:dobj-11-6dv3jd75"
+      },
+      {
+        "output": "sr_bbcms_fq",
+        "name": "bbcms error corrected reads",
+        "data_object_type": "Error Corrected Reads",
+        "description": "Error corrected reads for {id}",
+        "id": "nmdc:dobj-11-x0qjva50"
+      }
+    ]
+  },
+  "claims": [
+    {
+      "op_id": "nmdc:sys0rxx8dh49",
+      "site_id": "NERSC"
+    }
+  ]
+},
+{
+  "workflow": {
+    "id": "Metagenome Annotation: v1.1.5"
+  },
+  "id": "nmdc:3b3ac7dc-3046-11f0-9188-6e3122654c51",
+  "created_at": {
+    "$date": "2025-05-13T22:04:24.000Z"
+  },
+  "config": {
+    "git_repo": "https://github.com/microbiomedata/mg_annotation",
+    "release": "v1.1.5",
+    "wdl": "annotation_full.wdl",
+    "activity_id": "nmdc:wfmgan-11-nm70y660.1",
+    "activity_set": "workflow_execution_set",
+    "was_informed_by": [
+      "nmdc:dgns-11-syr2vn62"
+    ],
+    "trigger_activity": "nmdc:wfmgas-11-83xhja56.1",
+    "iteration": 1,
+    "input_prefix": "annotation",
+    "inputs": {
+      "input_file": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgas-11-83xhja56.1/nmdc_wfmgas-11-83xhja56.1_contigs.fna",
+      "imgap_project_id": "scaffold",
+      "proj": "nmdc:wfmgan-11-nm70y660.1"
+    },
+    "input_data_objects": [
+      {
+        "id": "nmdc:dobj-11-a84z9455",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgas-11-83xhja56.1_contigs.fna",
+        "description": "Assembly contigs for nmdc:wfmgas-11-83xhja56.1",
+        "data_category": "processed_data",
+        "data_object_type": "Assembly Contigs",
+        "file_size_bytes": 2234286,
+        "md5_checksum": "26dbe0fa7a9b022d07cc9fcfbb557d35",
+        "url": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgas-11-83xhja56.1/nmdc_wfmgas-11-83xhja56.1_contigs.fna",
+        "was_generated_by": "nmdc:wfmgas-11-83xhja56.1"
+      }
+    ],
+    "activity": {
+      "name": "Metagenome Annotation Analysis for {id}",
+      "type": "nmdc:MetagenomeAnnotation"
+    },
+    "outputs": [
+      {
+        "output": "proteins_faa",
+        "data_object_type": "Annotation Amino Acid FASTA",
+        "description": "FASTA Amino Acid File for {id}",
+        "name": "FASTA amino acid file for annotated proteins",
+        "id": "nmdc:dobj-11-xqncfh79"
+      },
+      {
+        "output": "structural_gff",
+        "data_object_type": "Structural Annotation GFF",
+        "description": "Structural Annotation for {id}",
+        "name": "GFF3 format file with structural annotations",
+        "id": "nmdc:dobj-11-h88eba44"
+      },
+      {
+        "output": "functional_gff",
+        "data_object_type": "Functional Annotation GFF",
+        "description": "Functional Annotation for {id}",
+        "name": "GFF3 format file with functional annotations",
+        "id": "nmdc:dobj-11-2pxy3e67"
+      },
+      {
+        "output": "ko_tsv",
+        "data_object_type": "Annotation KEGG Orthology",
+        "description": "KEGG Orthology for {id}",
+        "name": "Tab delimited file for KO annotation",
+        "id": "nmdc:dobj-11-j0hvvx85"
+      },
+      {
+        "output": "ec_tsv",
+        "data_object_type": "Annotation Enzyme Commission",
+        "description": "EC Annotations for {id}",
+        "name": "Tab delimited file for EC annotation",
+        "suffix": "_ec.tsv",
+        "id": "nmdc:dobj-11-55468551"
+      },
+      {
+        "output": "lineage_tsv",
+        "data_object_type": "Scaffold Lineage tsv",
+        "description": "Scaffold Lineage tsv for {id}",
+        "name": "Phylogeny at the scaffold level",
+        "suffix": "_scaffold_lineage.tsv",
+        "id": "nmdc:dobj-11-dkz5e809"
+      },
+      {
+        "output": "cog_gff",
+        "data_object_type": "Clusters of Orthologous Groups (COG) Annotation GFF",
+        "description": "COGs for {id}",
+        "name": "GFF3 format file with COGs",
+        "id": "nmdc:dobj-11-zmsnyx46"
+      },
+      {
+        "output": "pfam_gff",
+        "data_object_type": "Pfam Annotation GFF",
+        "description": "Pfam Annotation for {id}",
+        "name": "GFF3 format file with Pfam",
+        "id": "nmdc:dobj-11-1bes6498"
+      },
+      {
+        "output": "tigrfam_gff",
+        "data_object_type": "TIGRFam Annotation GFF",
+        "description": "TIGRFam for {id}",
+        "name": "GFF3 format file with TIGRfam",
+        "id": "nmdc:dobj-11-yevws659"
+      },
+      {
+        "output": "smart_gff",
+        "data_object_type": "SMART Annotation GFF",
+        "description": "SMART Annotations for {id}",
+        "name": "GFF3 format file with SMART",
+        "id": "nmdc:dobj-11-kk2j2459"
+      },
+      {
+        "output": "supfam_gff",
+        "data_object_type": "SUPERFam Annotation GFF",
+        "description": "SUPERFam Annotations for {id}",
+        "name": "GFF3 format file with SUPERFam",
+        "id": "nmdc:dobj-11-dmg53z71"
+      },
+      {
+        "output": "cath_funfam_gff",
+        "data_object_type": "CATH FunFams (Functional Families) Annotation GFF",
+        "description": "CATH FunFams for {id}",
+        "name": "GFF3 format file with CATH FunFams",
+        "id": "nmdc:dobj-11-0529je89"
+      },
+      {
+        "output": "crt_gff",
+        "data_object_type": "CRT Annotation GFF",
+        "description": "CRT Annotations for {id}",
+        "name": "GFF3 format file with CRT",
+        "id": "nmdc:dobj-11-36r6eb22"
+      },
+      {
+        "output": "genemark_gff",
+        "data_object_type": "Genemark Annotation GFF",
+        "description": "Genemark Annotations for {id}",
+        "name": "GFF3 format file with Genemark",
+        "id": "nmdc:dobj-11-7cjqgb63"
+      },
+      {
+        "output": "prodigal_gff",
+        "data_object_type": "Prodigal Annotation GFF",
+        "description": "Prodigal Annotations {id}",
+        "name": "GFF3 format file with Prodigal",
+        "id": "nmdc:dobj-11-swyyt216"
+      },
+      {
+        "output": "trna_gff",
+        "data_object_type": "TRNA Annotation GFF",
+        "description": "TRNA Annotations {id}",
+        "name": "GFF3 format file with TRNA",
+        "id": "nmdc:dobj-11-x1c40e18"
+      },
+      {
+        "output": "final_rfam_gff",
+        "data_object_type": "RFAM Annotation GFF",
+        "description": "RFAM Annotations for {id}",
+        "name": "GFF3 format file with RFAM",
+        "id": "nmdc:dobj-11-m6n24f06"
+      },
+      {
+        "output": "ko_ec_gff",
+        "data_object_type": "KO_EC Annotation GFF",
+        "description": "KO_EC Annotations for {id}",
+        "name": "GFF3 format file with KO_EC",
+        "id": "nmdc:dobj-11-wfw60c15"
+      },
+      {
+        "output": "product_names_tsv",
+        "data_object_type": "Product Names",
+        "description": "Product names for {id}",
+        "name": "Product names file",
+        "id": "nmdc:dobj-11-vjp29s55"
+      },
+      {
+        "output": "gene_phylogeny_tsv",
+        "data_object_type": "Gene Phylogeny tsv",
+        "description": "Gene Phylogeny for {id}",
+        "name": "Gene Phylogeny file",
+        "id": "nmdc:dobj-11-bnrq6272"
+      },
+      {
+        "output": "crt_crisprs",
+        "data_object_type": "Crispr Terms",
+        "description": "Crispr Terms for {id}",
+        "name": "Crispr Terms",
+        "id": "nmdc:dobj-11-yam4sn07"
+      },
+      {
+        "output": "stats_tsv",
+        "data_object_type": "Annotation Statistics",
+        "description": "Annotation Stats for {id}",
+        "name": "Annotation statistics report",
+        "id": "nmdc:dobj-11-gdtb4k14"
+      },
+      {
+        "output": "map_file",
+        "data_object_type": "Contig Mapping File",
+        "description": "Contig mappings file for {id}",
+        "name": "Contig mappings between contigs and scaffolds",
+        "id": "nmdc:dobj-11-r948bf33"
+      },
+      {
+        "output": "imgap_version",
+        "data_object_type": "Annotation Info File",
+        "description": "Annotation info for {id}",
+        "name": "File containing annotation info",
+        "id": "nmdc:dobj-11-83y7z997"
+      },
+      {
+        "output": "renamed_fasta",
+        "data_object_type": "Assembly Contigs",
+        "description": "Assembly contigs (remapped) for {id}",
+        "name": "File containing contigs with annotation headers",
+        "id": "nmdc:dobj-11-vr2e2n32"
+      }
+    ]
+  },
+  "claims": [
+    {
+      "op_id": "nmdc:sys0tjsacy67",
+      "site_id": "NERSC",
+      "done": true,
+      "cancelled": true
+    },
+    {
+      "op_id": "nmdc:sys0m0p0sr98",
+      "site_id": "NERSC"
+    }
+  ]
+},
+{
+  "workflow": {
+    "id": "MAGs: v1.3.16"
+  },
+  "id": "nmdc:81ceab44-4704-11f0-8cb1-6ecfcf3c8e48",
+  "created_at": {
+    "$date": "2025-06-11T20:41:53.000Z"
+  },
+  "config": {
+    "git_repo": "https://github.com/microbiomedata/metaMAGs",
+    "release": "v1.3.16",
+    "wdl": "mbin_nmdc.wdl",
+    "activity_id": "nmdc:wfmag-11-adjq5j31.1",
+    "activity_set": "workflow_execution_set",
+    "was_informed_by": [
+      "nmdc:dgns-11-syr2vn62"
+    ],
+    "trigger_activity": "nmdc:wfmgan-11-nm70y660.1",
+    "iteration": 1,
+    "input_prefix": "nmdc_mags",
+    "inputs": {
+      "proj": "nmdc:wfmag-11-adjq5j31.1",
+      "contig_file": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_contigs.fna",
+      "sam_file": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgas-11-83xhja56.1/nmdc_wfmgas-11-83xhja56.1_pairedMapped_sorted.bam",
+      "gff_file": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_functional_annotation.gff",
+      "proteins_file": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_proteins.faa",
+      "cog_file": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_cog.gff",
+      "ec_file": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_ec.tsv",
+      "ko_file": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_ko.tsv",
+      "pfam_file": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_pfam.gff",
+      "tigrfam_file": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_tigrfam.gff",
+      "crispr_file": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_crt.crisprs",
+      "product_names_file": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_product_names.tsv",
+      "gene_phylogeny_file": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_gene_phylogeny.tsv",
+      "lineage_file": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_scaffold_lineage.tsv",
+      "map_file": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_contig_names_mapping.tsv"
+    },
+    "input_data_objects": [
+      {
+        "id": "nmdc:dobj-11-vr2e2n32",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-nm70y660.1_contigs.fna",
+        "description": "Assembly contigs (remapped) for nmdc:wfmgan-11-nm70y660.1",
+        "data_category": "processed_data",
+        "data_object_type": "Assembly Contigs",
+        "file_size_bytes": 2219025,
+        "md5_checksum": "0b8dd97c0e56c5cd0cf3b0459a2f346f",
+        "url": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_contigs.fna",
+        "was_generated_by": "nmdc:wfmgan-11-nm70y660.1"
+      },
+      {
+        "id": "nmdc:dobj-11-23k58474",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgas-11-83xhja56.1_pairedMapped_sorted.bam",
+        "description": "Sorted Bam for nmdc:wfmgas-11-83xhja56.1",
+        "data_category": "processed_data",
+        "data_object_type": "Assembly Coverage BAM",
+        "file_size_bytes": 245037855,
+        "md5_checksum": "a148e0b6bf36bedd0364f586df1bab0c",
+        "url": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgas-11-83xhja56.1/nmdc_wfmgas-11-83xhja56.1_pairedMapped_sorted.bam",
+        "was_generated_by": "nmdc:wfmgas-11-83xhja56.1"
+      },
+      {
+        "id": "nmdc:dobj-11-2pxy3e67",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-nm70y660.1_functional_annotation.gff",
+        "description": "Functional Annotation for nmdc:wfmgan-11-nm70y660.1",
+        "data_category": "processed_data",
+        "data_object_type": "Functional Annotation GFF",
+        "file_size_bytes": 1766138,
+        "md5_checksum": "e5a3d353a60064b5af3ba21b277b0472",
+        "url": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_functional_annotation.gff",
+        "was_generated_by": "nmdc:wfmgan-11-nm70y660.1"
+      },
+      {
+        "id": "nmdc:dobj-11-xqncfh79",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-nm70y660.1_proteins.faa",
+        "description": "FASTA Amino Acid File for nmdc:wfmgan-11-nm70y660.1",
+        "data_category": "processed_data",
+        "data_object_type": "Annotation Amino Acid FASTA",
+        "file_size_bytes": 1244618,
+        "md5_checksum": "a60abd91257feb43689d2baec5832098",
+        "url": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_proteins.faa",
+        "was_generated_by": "nmdc:wfmgan-11-nm70y660.1"
+      },
+      {
+        "id": "nmdc:dobj-11-zmsnyx46",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-nm70y660.1_cog.gff",
+        "description": "COGs for nmdc:wfmgan-11-nm70y660.1",
+        "data_category": "processed_data",
+        "data_object_type": "Clusters of Orthologous Groups (COG) Annotation GFF",
+        "file_size_bytes": 1050699,
+        "md5_checksum": "5e32c1a6bd8c1adee674cbb8805489f3",
+        "url": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_cog.gff",
+        "was_generated_by": "nmdc:wfmgan-11-nm70y660.1"
+      },
+      {
+        "id": "nmdc:dobj-11-55468551",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-nm70y660.1_ec.tsv",
+        "description": "EC Annotations for nmdc:wfmgan-11-nm70y660.1",
+        "data_category": "processed_data",
+        "data_object_type": "Annotation Enzyme Commission",
+        "file_size_bytes": 164624,
+        "md5_checksum": "9355bb7d12e8dc2efdacaac3d1cacff6",
+        "url": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_ec.tsv",
+        "was_generated_by": "nmdc:wfmgan-11-nm70y660.1"
+      },
+      {
+        "id": "nmdc:dobj-11-j0hvvx85",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-nm70y660.1_ko.tsv",
+        "description": "KEGG Orthology for nmdc:wfmgan-11-nm70y660.1",
+        "data_category": "processed_data",
+        "data_object_type": "Annotation KEGG Orthology",
+        "file_size_bytes": 243195,
+        "md5_checksum": "9f9b16f3e84aa3ab0530aecdc8babad5",
+        "url": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_ko.tsv",
+        "was_generated_by": "nmdc:wfmgan-11-nm70y660.1"
+      },
+      {
+        "id": "nmdc:dobj-11-1bes6498",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-nm70y660.1_pfam.gff",
+        "description": "Pfam Annotation for nmdc:wfmgan-11-nm70y660.1",
+        "data_category": "processed_data",
+        "data_object_type": "Pfam Annotation GFF",
+        "file_size_bytes": 800713,
+        "md5_checksum": "8224c75c7e0e4ba48dda2665f82c73ef",
+        "url": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_pfam.gff",
+        "was_generated_by": "nmdc:wfmgan-11-nm70y660.1"
+      },
+      {
+        "id": "nmdc:dobj-11-yevws659",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-nm70y660.1_tigrfam.gff",
+        "description": "TIGRFam for nmdc:wfmgan-11-nm70y660.1",
+        "data_category": "processed_data",
+        "data_object_type": "TIGRFam Annotation GFF",
+        "file_size_bytes": 67698,
+        "md5_checksum": "e6c5a360dcade434d9c14ea9f1cc1269",
+        "url": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_tigrfam.gff",
+        "was_generated_by": "nmdc:wfmgan-11-nm70y660.1"
+      },
+      {
+        "id": "nmdc:dobj-11-yam4sn07",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-nm70y660.1_crt.crisprs",
+        "description": "Crispr Terms for nmdc:wfmgan-11-nm70y660.1",
+        "data_category": "processed_data",
+        "data_object_type": "Crispr Terms",
+        "file_size_bytes": 0,
+        "md5_checksum": "d41d8cd98f00b204e9800998ecf8427e",
+        "url": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_crt.crisprs",
+        "was_generated_by": "nmdc:wfmgan-11-nm70y660.1"
+      },
+      {
+        "id": "nmdc:dobj-11-vjp29s55",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-nm70y660.1_product_names.tsv",
+        "description": "Product names for nmdc:wfmgan-11-nm70y660.1",
+        "data_category": "processed_data",
+        "data_object_type": "Product Names",
+        "file_size_bytes": 509977,
+        "md5_checksum": "9ae4134e126d8e7f4df149bea1b52545",
+        "url": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_product_names.tsv",
+        "was_generated_by": "nmdc:wfmgan-11-nm70y660.1"
+      },
+      {
+        "id": "nmdc:dobj-11-bnrq6272",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-nm70y660.1_gene_phylogeny.tsv",
+        "description": "Gene Phylogeny for nmdc:wfmgan-11-nm70y660.1",
+        "data_category": "processed_data",
+        "data_object_type": "Gene Phylogeny tsv",
+        "file_size_bytes": 1024632,
+        "md5_checksum": "49713b0360d07af6657e46ba15e0a8ef",
+        "url": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_gene_phylogeny.tsv",
+        "was_generated_by": "nmdc:wfmgan-11-nm70y660.1"
+      },
+      {
+        "id": "nmdc:dobj-11-dkz5e809",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-nm70y660.1_scaffold_lineage.tsv",
+        "description": "Scaffold Lineage tsv for nmdc:wfmgan-11-nm70y660.1",
+        "data_category": "processed_data",
+        "data_object_type": "Scaffold Lineage tsv",
+        "file_size_bytes": 819704,
+        "md5_checksum": "0ec5add1ae73360981acd97d92b00aea",
+        "url": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_scaffold_lineage.tsv",
+        "was_generated_by": "nmdc:wfmgan-11-nm70y660.1"
+      },
+      {
+        "id": "nmdc:dobj-11-r948bf33",
+        "type": "nmdc:DataObject",
+        "name": "nmdc_wfmgan-11-nm70y660.1_contig_names_mapping.tsv",
+        "description": "Contig mappings file for nmdc:wfmgan-11-nm70y660.1",
+        "data_category": "processed_data",
+        "data_object_type": "Contig Mapping File",
+        "file_size_bytes": 353533,
+        "md5_checksum": "51d6dc2a22f5300cbf0371f7e34927ed",
+        "url": "https://data.microbiomedata.org/data/nmdc:dgns-11-syr2vn62/nmdc:wfmgan-11-nm70y660.1/nmdc_wfmgan-11-nm70y660.1_contig_names_mapping.tsv",
+        "was_generated_by": "nmdc:wfmgan-11-nm70y660.1"
+      }
+    ],
+    "activity": {
+      "name": "Metagenome Assembled Genomes Analysis for {id}",
+      "type": "nmdc:MagsAnalysis",
+      "binned_contig_num": "{outputs.final_stats_json.binned_contig_num}",
+      "input_contig_num": "{outputs.final_stats_json.input_contig_num}",
+      "low_depth_contig_num": "{outputs.final_stats_json.low_depth_contig_num}",
+      "mags_list": "{outputs.final_stats_json.mags_list}",
+      "too_short_contig_num": "{outputs.final_stats_json.too_short_contig_num}",
+      "unbinned_contig_num": "{outputs.final_stats_json.unbinned_contig_num}"
+    },
+    "outputs": [
+      {
+        "output": "final_checkm",
+        "data_object_type": "CheckM Statistics",
+        "description": "CheckM for {id}",
+        "name": "CheckM statistics report",
+        "id": "nmdc:dobj-11-vdzxvs58"
+      },
+      {
+        "output": "final_hqmq_bins_zip",
+        "data_object_type": "Metagenome HQMQ Bins Compression File",
+        "description": "Metagenome HQMQ Bins for {id}",
+        "name": "Metagenome hqmq bin zip archive",
+        "id": "nmdc:dobj-11-cbkr8g77"
+      },
+      {
+        "output": "final_gtdbtk_bac_summary",
+        "data_object_type": "GTDBTK Bacterial Summary",
+        "description": "Bacterial Summary for {id}",
+        "name": "GTDBTK bacterial summary",
+        "id": "nmdc:dobj-11-0xcamd40"
+      },
+      {
+        "output": "final_gtdbtk_ar_summary",
+        "data_object_type": "GTDBTK Archaeal Summary",
+        "description": "Archaeal Summary for {id}",
+        "name": "GTDBTK archaeal summary",
+        "suffix": "_gtdbtk.ar122.summary.tsv",
+        "id": "nmdc:dobj-11-q82k4g85"
+      },
+      {
+        "output": "mags_version",
+        "data_object_type": "Metagenome Bins Info File",
+        "description": "Metagenome Bins Info File for {id}",
+        "name": "Metagenome Bins Info File",
+        "id": "nmdc:dobj-11-ak0kbj90"
+      },
+      {
+        "output": "final_lq_bins_zip",
+        "data_object_type": "Metagenome LQ Bins Compression File",
+        "description": "Metagenome LQ Bins for {id}",
+        "name": "Metagenome lq bin zip archive",
+        "id": "nmdc:dobj-11-qk6w5828"
+      },
+      {
+        "output": "heatmap",
+        "data_object_type": "Metagenome Bins Heatmap",
+        "description": "Metagenome heatmap for {id}",
+        "name": "Metagenome Heatmap File",
+        "id": "nmdc:dobj-11-fbfras48"
+      },
+      {
+        "output": "barplot",
+        "data_object_type": "Metagenome Bins Barplot",
+        "description": "Metagenome barplot for {id}",
+        "name": "Metagenome Barplot File",
+        "id": "nmdc:dobj-11-dw6v1570"
+      },
+      {
+        "output": "kronaplot",
+        "data_object_type": "Metagenome Bins Krona Plot",
+        "description": "Metagenome Bins Krona Plot for {id}",
+        "name": "Metagenome Krona Bins Plot File",
+        "id": "nmdc:dobj-11-gngt6548"
+      }
+    ]
+  },
+  "claims": [
+    {
+      "op_id": "nmdc:sys0chwq0560",
+      "site_id": "NERSC"
+    }
+  ]
+}]

--- a/tests/fixtures/nmdc_db/manifest_set_update.json
+++ b/tests/fixtures/nmdc_db/manifest_set_update.json
@@ -1,0 +1,6 @@
+[{
+  "id": "nmdc:manif-11-f8gt6f52",
+  "name": "Poolable replicates manifest for STER_028-M-20170605-COMP-DNA1",
+  "manifest_category": "poolable_replicates",
+  "type": "nmdc:Manifest"
+}]

--- a/tests/fixtures/nmdc_db/workflow_execution_manifest_update_readsqc.json
+++ b/tests/fixtures/nmdc_db/workflow_execution_manifest_update_readsqc.json
@@ -1,0 +1,25 @@
+[
+  {
+  "id": "test-manifest-rqc-id.1",
+  "type": "nmdc:ReadQcAnalysis",
+  "name": "Read QC for nmdc:wfrqc-11-2rg3xg37.1",
+  "has_input": [
+    "nmdc:dobj-11-kpt53f77",
+    "nmdc:dobj-11-tv9g1670"
+  ],
+  "has_output": [
+    "nmdc:dobj-11-r1dngr87",
+    "nmdc:dobj-11-dpb8yd39",
+    "nmdc:dobj-11-j5xkvb53"
+  ],
+  "execution_resource": "NERSC-Perlmutter",
+  "git_url": "https://github.com/microbiomedata/ReadsQC",
+  "started_at_time": "2025-05-05T18:28:24.026896+00:00",
+  "was_informed_by": [
+    "nmdc:dgns-11-syr2vn62",
+    "nmdc:dgns-11-kwb7eq83"
+  ],
+  "version": "v1.0.28",
+  "processing_institution": "NMDC"
+  }
+]

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -1163,3 +1163,66 @@ def test_resolve_data_object_urls(test_db, test_client, workflows_config_dir, si
             for fq1 in input_fq1s:
                 assert "storage.googleapis.com" in fq1
                 assert "storage.neonscience.org" not in fq1
+
+
+
+@mark.parametrize("allowlist_permutation", [
+    ("nmdc:dgns-11-syr2vn62",),  # has historical individual jobs in the DB
+    ("nmdc:dgns-11-kwb7eq83",),  # new, zero job history
+    ("nmdc:dgns-11-syr2vn62","nmdc:dgns-11-kwb7eq83")  # Both together
+])
+def test_manifest_repooling_permutations_multicycle(allowlist_permutation, test_db, test_client, workflows_config_dir, site_config_file):
+    """
+    Validates a complete multi-cycle manifest pipeline across all allowlist permutations.
+    No matter which ID (or combination of IDs) is allowed, the scheduler should always
+    ignore legacy single-sample records and properly schedule a unified manifest pool.
+    """
+
+    # Reset the database state completely
+    reset_db(test_db)
+
+    # Load all manifest infrastructure components at once
+    load_fixture(test_db, "data_objects_in_manifest_update.json", "data_object_set")
+    load_fixture(test_db, "data_generation_in_manifest_update.json", "data_generation_set")
+    load_fixture(test_db, "manifest_set_update.json", "manifest_set")
+    
+    # Load the legacy individual job history with mdc:dgns-11-syr2vn62
+    load_fixture(test_db, "job_manifest_update_indiv_done.json", "jobs")
+
+
+    # Scheduler cycle expected jobs count
+    exp_num_jobs_initial = 1
+    exp_num_jobs_cycle_1 = 0
+    exp_num_jobs_cycle_2 = 2
+    exp_num_jobs_cycle_3 = 0
+    
+    jm = Scheduler(workflow_yaml=workflows_config_dir / "workflows.yaml",
+                   site_conf=site_config_file, api=test_client)
+    
+    current_allowlist = set(allowlist_permutation)
+    with patch.object(jm.api, 'minter', return_value="mock-id-123"):
+        resp = jm.cycle(allowlist=current_allowlist)
+
+        # The scheduler must bypass the individual jobs and create exactly 1 manifest job
+        assert len(resp) == exp_num_jobs_initial
+        assert resp[0]["config"]["activity"]["type"] == "nmdc:ReadQcAnalysis"
+
+        # All jobs should now be in a submitted state
+        resp = jm.cycle(allowlist=current_allowlist)
+        assert len(resp) == exp_num_jobs_cycle_1
+
+
+        #
+        # Now make the ReadsQC job complete
+        #
+    
+        # Load the finished readsQC so that assembly and readbased taxnomy will schedule
+        load_fixture(test_db, "workflow_execution_manifest_update_readsqc.json", "workflow_execution_set")
+
+        # Schedule the next 2 jobs downstream
+        resp = jm.cycle(allowlist=current_allowlist)
+        assert len(resp) == exp_num_jobs_cycle_2
+
+        # All jobs should now be in a submitted state
+        resp = jm.cycle(allowlist=current_allowlist)
+        assert len(resp) == exp_num_jobs_cycle_3


### PR DESCRIPTION
Updated get_existing_jobs to handle finding manifest-related jobs when in_manifest exists so that individual completed jobs for a dgns ID are ignored when needing to schedule new manifest jobs.