### PR TITLE
Update Slack notification function to redact auth tokens from message

### DIFF
--- a/bin/run_scheduler.sh
+++ b/bin/run_scheduler.sh
@@ -128,6 +128,11 @@ send_slack_notification() {
         return
     fi
     local message="$1"
+
+    # If the message contains a single-quoted HTTP header that includes an auth token,
+    # replace the auth token with ellipses (i.e. "...").
+    message="$(printf '%s\n' "$message" | sed "s/'Authorization': 'Bearer [^']*'/'Authorization': 'Bearer ...'/g")"
+
     curl -s -X POST -H 'Content-type: application/json' \
          --data "{\"text\": \"$message\"}" \
          "$SLACK_WEBHOOK_URL" > /dev/null

--- a/bin/run_watcher.sh
+++ b/bin/run_watcher.sh
@@ -105,6 +105,11 @@ send_slack_notification() {
         return
     fi
     local message="$1"
+
+    # If the message contains a single-quoted HTTP header that includes an auth token,
+    # replace the auth token with ellipses (i.e. "...").
+    message="$(printf '%s\n' "$message" | sed "s/'Authorization': 'Bearer [^']*'/'Authorization': 'Bearer ...'/g")"
+
     curl -s -X POST -H 'Content-type: application/json' \
          --data "{\"text\": \"$message\"}" \
          "$SLACK_WEBHOOK_URL" > /dev/null


### PR DESCRIPTION
#### Summary

On this branch, I updated the bash function named `send_slack_notification` so that, if the original message is:

```py
ERROR: Response failed for: url: https://example.com/endpoint, data: {'Authorization': 'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3ODM0MDA2MjYsImV4cCI6MTc4MzQwNDIyNiwianRpIjoiNTYxNmE4OTItMDNlNi00ODZkLWEwYzUtNzEyNDRlMGFkMTc0IiwiaXNzIjoiYXBpLmV4YW1wbGUuY29tIiwic3ViIjoidXNlcl84MDI3IiwiYXVkIjoiaHR0cHM6Ly9leGFtcGxlLmNvbSJ9.BJhxX1vu7Hnpm2spf-Vv4V0xn5yqKxS2Q0p_m5OOWrY', 'OtherHeader': 'OtherValue'}
```

The final message will be:

```py
ERROR: Response failed for: url: https://example.com/endpoint, data: {'Authorization': 'Bearer ...', 'OtherHeader': 'OtherValue'}
```

In other words...

```py
    # If the message contains a single-quoted HTTP header that includes an auth token,
    # replace the auth token with ellipses (i.e. "...").
```

...thereby preventing it from appearing in Slack messages.

#### Testing

I tested this by creating a bash script locally and confirming it does what I expect.

<img width="1041" height="121" alt="image" src="https://github.com/user-attachments/assets/eabf75b3-0e53-4faf-9cc5-2047a0e15fcf" />

#### Guidance for reviewers

Here's an explanation of the new line of code:

- `message="$()"` assigns the output of the specified command, to the `message` variable
- `printf '%s\n' "$message" | ` sends the original message to whatever comes after the `|`
- `sed "s/A/B/g"` replaces all substrings that match (A) `'Authorization': 'Bearer [^']*'`, with (B) `'Authorization': 'Bearer ...'` (I chose `*` instead of `+` because sed doesn't treat `+` as 'one or more' unless I escape it or put sed into [extended regex mode](https://www.gnu.org/software/sed/manual/html_node/Extended-regexps.html), which I didn't want to do since I thought it would complicate the diff here)

Fixes #753 

> Note: All example tokens above are random ones from an online test data generator, not real ones.