### PR TITLE
fix sra scheduler logic

### DIFF
--- a/nmdc_automation/config/workflows/workflows.yaml
+++ b/nmdc_automation/config/workflows/workflows.yaml
@@ -6,6 +6,7 @@ Workflows:
     Filter Output Objects:
     - Metagenome Raw Read 1
     - Metagenome Raw Read 2
+    - SRA toolkit-accessible sequence data
 
   - Name: Sequencing Interleaved
     Collection: data_generation_set
@@ -68,10 +69,11 @@ Workflows:
       input_fq2: do:Metagenome Raw Read 2
       shortRead: true
       interleaved: false
-      accessions: Accessions
+      accessions: do:SRA toolkit-accessible sequence data
     Filter Input Objects:
     - Metagenome Raw Read 1
     - Metagenome Raw Read 2
+    - SRA toolkit-accessible sequence data
     Predecessors:
     - Sequencing Noninterleaved
     Workflow Execution:

--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -9,7 +9,10 @@ from nmdc_automation.api.nmdcapi import NmdcRuntimeApi
 #from nmdc_automation.db.nmdc_mongo import get_db
 from nmdc_automation.workflow_automation.workflows import load_workflow_configs
 from functools import lru_cache
-from nmdc_automation.workflow_automation.workflow_process import load_workflow_process_nodes
+from nmdc_automation.workflow_automation.workflow_process import (
+    load_workflow_process_nodes,
+    required_data_object_types_satisfied,
+)
 from nmdc_automation.models.workflow import WorkflowConfig, WorkflowProcessNode
 from semver.version import Version
 import sys
@@ -221,7 +224,6 @@ class Scheduler:
             for obj_list in do_by_type.values()
             for obj in obj_list
         ]
-        sra = 'SRA toolkit-accessible sequence data' in data_object_types
         for k, v in job.workflow.inputs.items():
             # some inputs are booleans and should not be modified
             if isinstance(v, bool):
@@ -234,9 +236,7 @@ class Scheduler:
                 if not dobj_list:
                     if k in optional_inputs:
                         continue
-                    if (do_type == 'Metagenome Raw Read 1' or do_type == 'Metagenome Raw Read 2') and sra:
-                        continue
-                    if do_type == 'SRA toolkit-accessible sequence data' and not sra:
+                    if required_data_object_types_satisfied([do_type], data_object_types):
                         continue
                     raise MissingDataObjectException(f"Unable to find {do_type} in {do_by_type}")
                 if len(dobj_list) == 1:

--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -164,6 +164,7 @@ class Scheduler:
         resolves all the information needed to create a
         job record.
         """
+
         # Get all the data objects
         next_act = job.trigger_act
         do_by_type = dict()
@@ -172,8 +173,6 @@ class Scheduler:
         wf_filters = job.workflow.filter_input_objects or []
         # Keep track of the source that provided the data for Filter Input Objects
         type_source_map = dict()
-        # Make list of accession ids
-        accessions = []
         
         while next_act:
 
@@ -182,6 +181,7 @@ class Scheduler:
             # Note: Currently only support one manifest per workflowprocessnode/datagen
             #
             if len(next_act.manifest) == 1 and job.trigger_id in manifest_map[next_act.manifest[0]]['data_generation_set']:
+                print(f"Found manifest: {next_act.manifest[0]}")
                 # Find the data objects associated with the manifest using manifest_map
                 for data_object in manifest_map[next_act.manifest[0]]['data_object_set']:
                     do_type = data_object.data_object_type_text
@@ -190,7 +190,8 @@ class Scheduler:
                     do_by_type[do_type].append(data_object)
             else:
                 for do_type, data_object in next_act.data_objects_by_type.items():
-
+                    print(f"Processing data object of type: {do_type} with ID: {data_object.id}")
+                    print(f"Workflow filters: {wf_filters}")
                     if do_type in wf_filters:
                         current_source = type_source_map.get(do_type)
                         # If we find this type in a new (higher) activity, wipe the downstream data
@@ -203,20 +204,14 @@ class Scheduler:
 
                     if do_type in do_by_type:
                         logger.debug(f"Ignoring Duplicate type: {do_type} {data_object.id} {next_act.id}")
+                        print(f"Ignoring Duplicate type: {do_type} {data_object.id} {next_act.id}")
                         continue
                     do_by_type[do_type] = []
                     do_by_type[do_type].append(data_object)
                     #do_by_type[do_type] = data_object #used to be scalar
-
-            dg_accessions = getattr(next_act.process, "insdc_experiment_identifiers", [])
-            if dg_accessions:
-                accessions.extend(dg_accessions)
             
             # do_by_type.update(next_act.data_objects_by_type.__dict__)
             next_act = next_act.parent
-
-        if accessions:
-            accessions = list(dict.fromkeys(accessions))
 
         wf = job.workflow
         base_id, iteration = self.get_activity_id(wf, job.informed_by)
@@ -225,7 +220,14 @@ class Scheduler:
         inputs = dict()
         optional_inputs = wf.optional_inputs
         fq_inputs = ["input_files", "input_fq1", "input_fq2", "input_fastq1", "input_fastq2"]
+        data_object_types = [
+            str(obj.data_object_type)
+            for obj_list in do_by_type.values()
+            for obj in obj_list
+        ]
+        sra = 'SRA toolkit-accessible sequence data' in data_object_types
         for k, v in job.workflow.inputs.items():
+            print(f"Processing input key: {k} with value: {v}")
             # some inputs are booleans and should not be modified
             if isinstance(v, bool):
                 inputs[k] = v
@@ -233,32 +235,37 @@ class Scheduler:
             # some inputs are data objects that we need to translate to urls
             elif v.startswith("do:"):
                 do_type = v[3:]
+                print(f"do_type: {do_type}")
                 dobj_list = do_by_type.get(do_type)
+                print(f"dobj_list: {dobj_list}")
                 if not dobj_list:
                     if k in optional_inputs:
                         continue
-                    if k in fq_inputs:
-                        if accessions:
-                            continue
-                        raise MissingDataObjectException(f"Unable to find {do_type} in {do_by_type} and no accession(s) provided")
+                    if (do_type == 'Metagenome Raw Read 1' or do_type == 'Metagenome Raw Read 2') and sra:
+                        continue
+                    if do_type == 'SRA toolkit-accessible sequence data' and not sra:
+                        continue
                     raise MissingDataObjectException(f"Unable to find {do_type} in {do_by_type}")
                 if len(dobj_list) == 1:
                     input_data_objects.append(dobj_list[0].as_dict())
-                
-                    if k in fq_inputs:
+                    if k == "accessions":
+                        for accession in dobj_list[0].insdc_run_identifiers:
+                            v = [accession.split('insdc.run:')[1]]
+                            print(f"Resolved input for key {k}: {v}")
+                    elif k in fq_inputs:
                         v = [resolve_url(dobj_list[0]["url"])]
                     else:
                         v = resolve_url(dobj_list[0]["url"])
-                
                 # For multi-input, it goes here to produce []
                 else:
                     v = []
                     for dobj in dobj_list:
                         input_data_objects.append(dobj.as_dict())
-    
-                        v.append(resolve_url(dobj["url"]))
-                        
-                    
+                        if k == "accessions":
+                            for accession in dobj.insdc_run_identifiers:
+                                v.append(accession.split('insdc.run:')[1])
+                        else:
+                            v.append(resolve_url(dobj["url"]))
             # TODO: Make this smarter
             elif v == "{was_informed_by}":
                 v = job.informed_by  #Check that this works for 1 or >1 todojp 20250911
@@ -266,13 +273,9 @@ class Scheduler:
                 v = workflow_execution_id
             elif v == "{predecessor_activity_id}":
                 v = job.trigger_act.id
-            elif v == "Accessions":
-                if accessions:
-                    v = accessions
-                else:
-                    continue
 
             inputs[k] = v
+            print(f"job inputs: {inputs}")
 
         # Build the respoonse
         job_config = {

--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -181,7 +181,6 @@ class Scheduler:
             # Note: Currently only support one manifest per workflowprocessnode/datagen
             #
             if len(next_act.manifest) == 1 and job.trigger_id in manifest_map[next_act.manifest[0]]['data_generation_set']:
-                print(f"Found manifest: {next_act.manifest[0]}")
                 # Find the data objects associated with the manifest using manifest_map
                 for data_object in manifest_map[next_act.manifest[0]]['data_object_set']:
                     do_type = data_object.data_object_type_text
@@ -190,8 +189,6 @@ class Scheduler:
                     do_by_type[do_type].append(data_object)
             else:
                 for do_type, data_object in next_act.data_objects_by_type.items():
-                    print(f"Processing data object of type: {do_type} with ID: {data_object.id}")
-                    print(f"Workflow filters: {wf_filters}")
                     if do_type in wf_filters:
                         current_source = type_source_map.get(do_type)
                         # If we find this type in a new (higher) activity, wipe the downstream data
@@ -204,7 +201,6 @@ class Scheduler:
 
                     if do_type in do_by_type:
                         logger.debug(f"Ignoring Duplicate type: {do_type} {data_object.id} {next_act.id}")
-                        print(f"Ignoring Duplicate type: {do_type} {data_object.id} {next_act.id}")
                         continue
                     do_by_type[do_type] = []
                     do_by_type[do_type].append(data_object)
@@ -227,7 +223,6 @@ class Scheduler:
         ]
         sra = 'SRA toolkit-accessible sequence data' in data_object_types
         for k, v in job.workflow.inputs.items():
-            print(f"Processing input key: {k} with value: {v}")
             # some inputs are booleans and should not be modified
             if isinstance(v, bool):
                 inputs[k] = v
@@ -235,9 +230,7 @@ class Scheduler:
             # some inputs are data objects that we need to translate to urls
             elif v.startswith("do:"):
                 do_type = v[3:]
-                print(f"do_type: {do_type}")
                 dobj_list = do_by_type.get(do_type)
-                print(f"dobj_list: {dobj_list}")
                 if not dobj_list:
                     if k in optional_inputs:
                         continue
@@ -251,7 +244,6 @@ class Scheduler:
                     if k == "accessions":
                         for accession in dobj_list[0].insdc_run_identifiers:
                             v = [accession.split('insdc.run:')[1]]
-                            print(f"Resolved input for key {k}: {v}")
                     elif k in fq_inputs:
                         v = [resolve_url(dobj_list[0]["url"])]
                     else:
@@ -275,7 +267,6 @@ class Scheduler:
                 v = job.trigger_act.id
 
             inputs[k] = v
-            print(f"job inputs: {inputs}")
 
         # Build the respoonse
         job_config = {

--- a/nmdc_automation/workflow_automation/workflow_process.py
+++ b/nmdc_automation/workflow_automation/workflow_process.py
@@ -126,7 +126,23 @@ def _check(match_types, data_object_ids, data_objs):
     for doid in data_object_ids:
         if doid in data_objs:
             do_types.add(data_objs[doid].data_object_type.code.text)
-    return match_set.issubset(do_types)
+    all_types = match_set.issubset(do_types)
+
+    # Special handling for data generation record outputs, which can have Raw Reads OR SRA types
+    if not all_types:
+        if (
+            not 'Metagenome Raw Read 1' in do_types
+            and not 'Metagenome Raw Read 2' in do_types
+            and 'SRA toolkit-accessible sequence data' in do_types
+        ):
+            all_types = True
+        if (
+            not 'SRA toolkit-accessible sequence data' in do_types
+            and 'Metagenome Raw Read 1' in do_types
+            and 'Metagenome Raw Read 2' in do_types
+        ):
+            all_types = True
+    return all_types
 
 
 def _is_missing_required_input_output(wf: WorkflowConfig, rec: dict, data_objects_by_id: Dict[str, DataObject]) -> bool:
@@ -140,26 +156,6 @@ def _is_missing_required_input_output(wf: WorkflowConfig, rec: dict, data_object
     match_out = _check(
         wf.filter_output_objects, rec.get("has_output"), data_objects_by_id
     )
-
-    do_types = next(iter(data_objects_by_id.values()))['data_object_type']
-
-    # Special handling for data generation record outputs, which can have Raw Reads OR SRA types
-    if (
-        not match_out
-        and wf.collection == "data_generation_set"
-    ): 
-        if (
-            not 'Metagenome Raw Read 1' in str(do_types)
-            and not 'Metagenome Raw Read 2' in str(do_types)
-            and 'SRA toolkit-accessible sequence data' in str(do_types)
-        ):
-            match_out = True
-        if (
-            not 'SRA toolkit-accessible sequence data' in str(do_types)
-            and 'Metagenome Raw Read 1' in str(do_types)
-            and 'Metagenome Raw Read 2' in str(do_types)
-        ):
-            match_out = True
 
     return not (match_in and match_out)
 

--- a/nmdc_automation/workflow_automation/workflow_process.py
+++ b/nmdc_automation/workflow_automation/workflow_process.py
@@ -111,6 +111,38 @@ def _within_range(ver1: str, ver2: str) -> bool:
         return True
     return False
 
+def required_data_object_types_satisfied(wf_input_types, available_data_object_types) -> bool:
+    """
+    Determine whether the available data object types satisfy the workflow's
+    required input types, including the SRA versus paired-read compatibility rule.
+    """
+    sra_data_object_type = "SRA toolkit-accessible sequence data"
+    raw_read_1_data_object_type = "Metagenome Raw Read 1"
+    raw_read_2_data_object_type = "Metagenome Raw Read 2"
+
+    if not wf_input_types:
+        return True
+
+    wf_input_set = set(wf_input_types)
+    do_types = set(available_data_object_types)
+
+    all_sra = sra_data_object_type in do_types and \
+        raw_read_1_data_object_type not in do_types and \
+        raw_read_2_data_object_type not in do_types
+    all_reads = raw_read_1_data_object_type in do_types and \
+        raw_read_2_data_object_type in do_types and \
+        sra_data_object_type not in do_types
+
+    if all_reads:
+        wf_input_set = wf_input_set - {sra_data_object_type}
+    if all_sra:
+        wf_input_set = wf_input_set - {
+            raw_read_1_data_object_type,
+            raw_read_2_data_object_type,
+        }
+
+    return wf_input_set.issubset(do_types)
+
 
 def _check(wf_input_types, data_object_ids, data_objs):
     """
@@ -119,25 +151,12 @@ def _check(wf_input_types, data_object_ids, data_objs):
     """
     if not data_object_ids:
         return False
-    if not wf_input_types or len(wf_input_types) == 0:
-        return True
-    wf_input_set = set(wf_input_types)
-    do_types = set()
+    do_types = []
     for doid in data_object_ids:
         if doid in data_objs:
-            do_types.add(data_objs[doid].data_object_type.code.text)
+            do_types.append(data_objs[doid].data_object_type.code.text)
 
-    all_do_types = bool()
-    sra_data = 'SRA toolkit-accessible sequence data' in do_types
-
-    # only allow sra dataobjects if they're the one and only data object type
-    if sra_data and len(do_types)==1:
-        all_do_types = True
-    else:
-        wf_input_set_nosra = wf_input_set - {'SRA toolkit-accessible sequence data'}
-        all_do_types = wf_input_set_nosra.issubset(do_types)
-
-    return all_do_types
+    return required_data_object_types_satisfied(wf_input_types, do_types)
 
 
 def _is_missing_required_input_output(wf: WorkflowConfig, rec: dict, data_objects_by_id: Dict[str, DataObject]) -> bool:

--- a/nmdc_automation/workflow_automation/workflow_process.py
+++ b/nmdc_automation/workflow_automation/workflow_process.py
@@ -112,37 +112,32 @@ def _within_range(ver1: str, ver2: str) -> bool:
     return False
 
 
-def _check(match_types, data_object_ids, data_objs):
+def _check(wf_input_types, data_object_ids, data_objs):
     """
     This iterates through a list of data objects and
     checks the type against the match types.
     """
     if not data_object_ids:
         return False
-    if not match_types or len(match_types) == 0:
+    if not wf_input_types or len(wf_input_types) == 0:
         return True
-    match_set = set(match_types)
+    wf_input_set = set(wf_input_types)
     do_types = set()
     for doid in data_object_ids:
         if doid in data_objs:
             do_types.add(data_objs[doid].data_object_type.code.text)
-    all_types = match_set.issubset(do_types)
 
-    # Special handling for data generation record outputs, which can have Raw Reads OR SRA types
-    if not all_types:
-        if (
-            not 'Metagenome Raw Read 1' in do_types
-            and not 'Metagenome Raw Read 2' in do_types
-            and 'SRA toolkit-accessible sequence data' in do_types
-        ):
-            all_types = True
-        if (
-            not 'SRA toolkit-accessible sequence data' in do_types
-            and 'Metagenome Raw Read 1' in do_types
-            and 'Metagenome Raw Read 2' in do_types
-        ):
-            all_types = True
-    return all_types
+    all_do_types = bool()
+    sra_data = 'SRA toolkit-accessible sequence data' in do_types
+
+    # only allow sra dataobjects if they're the one and only data object type
+    if sra_data and len(do_types)==1:
+        all_do_types = True
+    else:
+        wf_input_set_nosra = wf_input_set - {'SRA toolkit-accessible sequence data'}
+        all_do_types = wf_input_set_nosra.issubset(do_types)
+
+    return all_do_types
 
 
 def _is_missing_required_input_output(wf: WorkflowConfig, rec: dict, data_objects_by_id: Dict[str, DataObject]) -> bool:

--- a/nmdc_automation/workflow_automation/workflow_process.py
+++ b/nmdc_automation/workflow_automation/workflow_process.py
@@ -141,15 +141,25 @@ def _is_missing_required_input_output(wf: WorkflowConfig, rec: dict, data_object
         wf.filter_output_objects, rec.get("has_output"), data_objects_by_id
     )
 
-    # Legacy sequencing records may not have has_output but can still be scheduled
-    # when INSDC experiment identifiers are present.
+    do_types = next(iter(data_objects_by_id.values()))['data_object_type']
+
+    # Special handling for data generation record outputs, which can have Raw Reads OR SRA types
     if (
         not match_out
         and wf.collection == "data_generation_set"
-        and not rec.get("has_output")
-        and rec.get("insdc_experiment_identifiers")
-    ):
-        match_out = True
+    ): 
+        if (
+            not 'Metagenome Raw Read 1' in str(do_types)
+            and not 'Metagenome Raw Read 2' in str(do_types)
+            and 'SRA toolkit-accessible sequence data' in str(do_types)
+        ):
+            match_out = True
+        if (
+            not 'SRA toolkit-accessible sequence data' in str(do_types)
+            and 'Metagenome Raw Read 1' in str(do_types)
+            and 'Metagenome Raw Read 2' in str(do_types)
+        ):
+            match_out = True
 
     return not (match_in and match_out)
 
@@ -208,7 +218,7 @@ def get_current_workflow_process_nodes(
             #If the dg record has outputs that are part of a manifest set, check that is the correct category to process,
             # and find the other data objects within the manifest set (in case it wasn't included in the allowlist)
             # Try to see if the has_output has a manifest set
-            do_ids = rec.get("has_output", [])
+            do_ids = rec.get("has_output")
 
             # Loop through the data_object IDs in the data genereation record's "has_output"
             for do_id in do_ids:

--- a/tests/fixtures/nmdc_db/data_generation_set_accession.json
+++ b/tests/fixtures/nmdc_db/data_generation_set_accession.json
@@ -1,5 +1,5 @@
 [
-  {
+      {
     "id" : "nmdc:omprc-11-metag1",
     "name" : "Test Metagenome Processing",
     "has_input" : [
@@ -22,15 +22,15 @@
     },
     "type" : "nmdc:NucleotideSequencing"
 },
-  {
+      {
     "id" : "nmdc:omprc-11-metag2",
     "name" : "Test Metagenome Processing",
     "has_input" : [
         "nmdc:bsm-11-qezc0h51"
     ],
-    "insdc_experiment_identifiers" : [
-        "SRX123456",
-        "SRX789012"
+    "has_output" : [
+        "nmdc:dobj-11-rawreads3",
+        "nmdc:dobj-11-rawreads4"
     ],
     "analyte_category": "metagenome",
     "associated_studies" : [
@@ -46,10 +46,57 @@
     "type" : "nmdc:NucleotideSequencing"
 },
   {
-    "id" : "nmdc:omprc-11-metag3",
+    "id" : "nmdc:dgns-11-access1",
     "name" : "Test Metagenome Processing",
     "has_input" : [
         "nmdc:bsm-11-qezc0h51"
+    ],
+    "has_output" : [
+        "nmdc:dobj-11-access1"
+    ],
+    "analyte_category": "metagenome",
+    "associated_studies" : [
+        "nmdc:sty-11-test001"
+    ],
+    "processing_institution": "JGI",
+    "principal_investigator" : {
+        "has_raw_value" : "PI Name",
+        "email" : "pi_name@example.com",
+        "name" : "PI Name",
+        "type": "nmdc:PersonValue"
+    },
+    "type" : "nmdc:NucleotideSequencing"
+},
+  {
+    "id" : "nmdc:dgns-11-access2",
+    "name" : "Test Metagenome Processing",
+    "has_input" : [
+        "nmdc:bsm-11-qezc0h51"
+    ],
+    "has_output" : [
+        "nmdc:dobj-11-access2"
+    ],
+    "analyte_category": "metagenome",
+    "associated_studies" : [
+        "nmdc:sty-11-test001"
+    ],
+    "processing_institution": "JGI",
+    "principal_investigator" : {
+        "has_raw_value" : "PI Name",
+        "email" : "pi_name@example.com",
+        "name" : "PI Name",
+        "type": "nmdc:PersonValue"
+    },
+    "type" : "nmdc:NucleotideSequencing"
+},
+  {
+    "id" : "nmdc:dgns-11-access3",
+    "name" : "Test Metagenome Processing",
+    "has_input" : [
+        "nmdc:bsm-11-qezc0h51"
+    ],
+    "has_output" : [
+        "nmdc:dobj-11-access3"
     ],
     "analyte_category": "metagenome",
     "associated_studies" : [

--- a/tests/fixtures/nmdc_db/data_generation_set_accession.json
+++ b/tests/fixtures/nmdc_db/data_generation_set_accession.json
@@ -45,6 +45,29 @@
     },
     "type" : "nmdc:NucleotideSequencing"
 },
+      {
+    "id" : "nmdc:omprc-11-duo",
+    "name" : "Test Metagenome Processing",
+    "has_input" : [
+        "nmdc:bsm-11-qezc0h51"
+    ],
+    "has_output" : [
+        "nmdc:dobj-11-rawreads5",
+        "nmdc:dobj-11-access4"
+    ],
+    "analyte_category": "metagenome",
+    "associated_studies" : [
+        "nmdc:sty-11-test001"
+    ],
+    "processing_institution": "JGI",
+    "principal_investigator" : {
+        "has_raw_value" : "PI Name",
+        "email" : "pi_name@example.com",
+        "name" : "PI Name",
+        "type": "nmdc:PersonValue"
+    },
+    "type" : "nmdc:NucleotideSequencing"
+},
   {
     "id" : "nmdc:dgns-11-access1",
     "name" : "Test Metagenome Processing",

--- a/tests/fixtures/nmdc_db/data_object_set_accession.json
+++ b/tests/fixtures/nmdc_db/data_object_set_accession.json
@@ -1,0 +1,121 @@
+[
+  {
+    "id": "nmdc:dobj-11-access1",
+    "type": "nmdc:DataObject",
+    "name": "Data file for run accession SRR28062759",
+    "description": "Data file for run accession SRR28062759",
+    "data_category": "instrument_data",
+    "data_object_type": "SRA toolkit-accessible sequence data",
+    "insdc_run_identifiers": [
+        "insdc.run:SRR28062759"
+    ],
+    "was_generated_by": "nmdc:dgns-11-access1"
+  },
+    {
+    "id": "nmdc:dobj-11-access2",
+    "type": "nmdc:DataObject",
+    "name": "Data file for run accession SRR28062638",
+    "description": "Data file for run accession SRR28062638",
+    "data_category": "instrument_data",
+    "data_object_type": "SRA toolkit-accessible sequence data",
+    "insdc_run_identifiers": [
+        "insdc.run:SRR28062638"
+    ],
+    "was_generated_by": "nmdc:dgns-11-access2",
+    "in_manifest": [
+      "nmdc:manif-11-manifest1"
+    ]
+  },
+{
+  "id": "nmdc:dobj-11-access3",
+  "type": "nmdc:DataObject",
+  "name": "Data file for run accession SRR28062761",
+  "description": "Data file for run accession SRR28062761",
+  "data_category": "instrument_data",
+  "data_object_type": "SRA toolkit-accessible sequence data",
+  "insdc_run_identifiers": [
+    "insdc.run:SRR28062761"
+  ],
+  "was_generated_by": "nmdc:dgns-11-access3",
+    "in_manifest": [
+      "nmdc:manif-11-manifest1"
+    ]
+  },
+  {
+    "id": "nmdc:dobj-11-rawreads2",
+    "name": "metaG_R2_001.fastq.gz",
+    "description": "Sequencing results for MetaG_R2",
+    "md5_checksum": "4c7f1be37f805836162b49da4ed9c7e5",
+    "data_object_type": "Metagenome Raw Read 2",
+    "type": "nmdc:DataObject",
+    "data_category": "instrument_data",
+    "url": "https://data.microbiomedata.org",
+    "in_manifest":[
+      "nmdc:manif-11-manifest2"
+    ]
+  },
+  {
+    "id": "nmdc:dobj-11-rawreads1",
+    "name": "metaG_R1_001.fastq.gz",
+    "description": "Sequencing results for metaG_R1",
+    "md5_checksum": "ed9467e690babb683b024ed47dd97b85",
+    "data_object_type": "Metagenome Raw Read 1",
+    "type": "nmdc:DataObject",
+    "data_category": "instrument_data",
+    "url": "https://data.microbiomedata.org",
+      "in_manifest":[
+      "nmdc:manif-11-manifest2"
+    ]
+  },
+    {
+    "id": "nmdc:dobj-11-rawreads3",
+    "name": "metaG_R2_001.fastq.gz",
+    "description": "Sequencing results for MetaG_R2",
+    "md5_checksum": "4c7f1be37f805836162b49da4ed9c7e5",
+    "data_object_type": "Metagenome Raw Read 2",
+    "type": "nmdc:DataObject",
+    "data_category": "instrument_data",
+    "url": "https://data.microbiomedata.org",
+    "in_manifest":[
+      "nmdc:manif-11-manifest2"
+    ]
+  },
+  {
+    "id": "nmdc:dobj-11-rawreads4",
+    "name": "metaG_R1_001.fastq.gz",
+    "description": "Sequencing results for metaG_R1",
+    "md5_checksum": "ed9467e690babb683b024ed47dd97b85",
+    "data_object_type": "Metagenome Raw Read 1",
+    "type": "nmdc:DataObject",
+    "data_category": "instrument_data",
+    "url": "https://data.microbiomedata.org",
+    "in_manifest":[
+      "nmdc:manif-11-manifest2"
+    ]
+  },
+    {
+    "id": "nmdc:dobj-11-rawreads5",
+    "name": "metaG_R1_001.fastq.gz",
+    "description": "Sequencing results for metaG_R1",
+    "md5_checksum": "ed9467e690babb683b024ed47dd97b85",
+    "data_object_type": "Metagenome Raw Read 1",
+    "type": "nmdc:DataObject",
+    "data_category": "instrument_data",
+    "url": "https://data.microbiomedata.org",
+    "in_manifest":[
+      "nmdc:manif-11-duo"
+    ]
+  },
+    {
+    "id": "nmdc:dobj-11-access4",
+    "type": "nmdc:DataObject",
+    "name": "Data file for run accession SRR28062759",
+    "description": "Data file for run accession SRR28062759",
+    "data_category": "instrument_data",
+    "data_object_type": "SRA toolkit-accessible sequence data",
+    "insdc_run_identifiers": [
+        "insdc.run:SRR28062759"
+    ],
+    "was_generated_by": "nmdc:dgns-11-duo"
+  }
+]

--- a/tests/fixtures/nmdc_db/manifest_accession.json
+++ b/tests/fixtures/nmdc_db/manifest_accession.json
@@ -1,0 +1,12 @@
+[
+    {
+        "id": "nmdc:manif-11-manifest1",
+        "manifest_category": "poolable_replicates",
+        "type": "nmdc:Manifest"
+    },
+        {
+        "id": "nmdc:manif-11-manifest2",
+        "manifest_category": "poolable_replicates",
+        "type": "nmdc:Manifest"
+    }
+]

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -389,12 +389,9 @@ def test_scheduler_create_job_rec_has_input_files_as_array(test_db, test_client,
 
 def test_scheduler_create_job_rec_handles_data_generation_without_has_output(test_db, test_client, workflows_config_dir, site_config_file):
     """
-    If a data_generation trigger has no has_output, create_job_rec should use
-    insdc_experiment_identifiers as accessions input.
+    Test that data objects with accession ids successfully make input jsons
     """
     reset_db(test_db)
-    #load_fixture(test_db, "data_object_set.json", "data_object_set")
-    #load_fixture(test_db, "data_generation_set.json", "data_generation_set")
     load_fixture(test_db, "data_object_set_accession.json", "data_object_set")
     load_fixture(test_db, "data_generation_set_accession.json", "data_generation_set")
     load_fixture(test_db, "manifest_accession.json", "manifest_set")
@@ -412,13 +409,20 @@ def test_scheduler_create_job_rec_handles_data_generation_without_has_output(tes
     for node in workflow_process_nodes:
         found_jobs = scheduler.find_new_jobs(node, manifest_map, new_jobs)
         new_jobs.extend(found_jobs)
-        #print(f"Found jobs for node {node.process}:")
-        #for job in found_jobs:
-            #print(f"Found job: {job.trigger_act.data_objects_by_type}")
 
+    # Filter to ReadsQC jobs
     rqc_jobs = [j for j in new_jobs if j.workflow.type == "nmdc:ReadQcAnalysis"]
     assert len(rqc_jobs) == 3 # one for metag1/metag2, one for access1, one for access2/access3
 
+    # Confirm job created for data objects associated with accession id
+    single_accession_job = next(j for j in rqc_jobs if j.trigger_id == "nmdc:dgns-11-access1")
+    single_accession_job_req = scheduler.create_job_rec(single_accession_job, manifest_map)
+    assert "accessions" in single_accession_job_req["config"]["inputs"]
+    assert len(single_accession_job_req["config"]["inputs"]["accessions"]) == 1
+    assert "input_fq1" not in single_accession_job_req["config"]["inputs"]
+    assert "input_fq2" not in single_accession_job_req["config"]["inputs"]
+
+    # Confirm data objects associated by manifest create single job
     accession_manifest_job = next(
         j for j in rqc_jobs
         if set(j.informed_by) == {"nmdc:dgns-11-access2", "nmdc:dgns-11-access3"}
@@ -429,13 +433,7 @@ def test_scheduler_create_job_rec_handles_data_generation_without_has_output(tes
     assert "input_fq1" not in accession_manifest_job_req["config"]["inputs"]
     assert "input_fq2" not in accession_manifest_job_req["config"]["inputs"]
 
-    single_accession_job = next(j for j in rqc_jobs if j.trigger_id == "nmdc:dgns-11-access1")
-    single_accession_job_req = scheduler.create_job_rec(single_accession_job, manifest_map)
-    assert "accessions" in single_accession_job_req["config"]["inputs"]
-    assert len(single_accession_job_req["config"]["inputs"]["accessions"]) == 1
-    assert "input_fq1" not in single_accession_job_req["config"]["inputs"]
-    assert "input_fq2" not in single_accession_job_req["config"]["inputs"]
-
+    # Confirm jobs still created for raw read objects associated by manifest
     dg_manifest_job = next(
         j for j in rqc_jobs
         if set(j.informed_by) == {"nmdc:omprc-11-metag1", "nmdc:omprc-11-metag2"}
@@ -443,22 +441,13 @@ def test_scheduler_create_job_rec_handles_data_generation_without_has_output(tes
     dg_manifest_job_req = scheduler.create_job_rec(dg_manifest_job, manifest_map)
     assert "accessions" not in dg_manifest_job_req["config"]["inputs"]
     assert "input_fq1" in dg_manifest_job_req["config"]["inputs"]
+    assert len(dg_manifest_job_req["config"]["inputs"]["input_fq1"]) == 2
     assert "input_fq2" in dg_manifest_job_req["config"]["inputs"]
+    assert len(dg_manifest_job_req["config"]["inputs"]["input_fq2"]) == 2
 
-
-    ## IM HERE: next need to add problem scenarios liek input_fq AND accessions
-    # also look at simplifying logic / making it more intuitive and less complicated
-
-    assert 1 == 2
-    '''
-
-    metag3_record = test_db.data_generation_set.find_one({"id": "nmdc:omprc-11-metag3"})
-    metag3_node = WorkflowProcessNode(metag3_record, raw_read_job.trigger_act.workflow)
-    bad_job = SchedulerJob(raw_read_job.workflow, metag3_node, manifest_map)
-    with pytest.raises(MissingDataObjectException):
-        scheduler.create_job_rec(bad_job, manifest_map)
-    '''
-
+    # Confirm no job created when a dg has one data object with a read and one with an accession
+    with pytest.raises(StopIteration):
+        next(j for j in rqc_jobs if j.trigger_id == "nmdc:omprc-11-duo")
 
 @pytest.mark.parametrize("job_fixture", [
     "job_req_2.json",

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -1,3 +1,4 @@
+from nmdc_automation.models import workflow
 from nmdc_automation.workflow_automation.sched import Scheduler, SchedulerJob, MissingDataObjectException
 from pytest import mark
 import pytest
@@ -392,8 +393,11 @@ def test_scheduler_create_job_rec_handles_data_generation_without_has_output(tes
     insdc_experiment_identifiers as accessions input.
     """
     reset_db(test_db)
-    load_fixture(test_db, "data_object_set.json", "data_object_set")
+    #load_fixture(test_db, "data_object_set.json", "data_object_set")
+    #load_fixture(test_db, "data_generation_set.json", "data_generation_set")
+    load_fixture(test_db, "data_object_set_accession.json", "data_object_set")
     load_fixture(test_db, "data_generation_set_accession.json", "data_generation_set")
+    load_fixture(test_db, "manifest_accession.json", "manifest_set")
 
     scheduler = Scheduler(
         workflow_yaml=workflows_config_dir / "workflows.yaml",
@@ -408,26 +412,52 @@ def test_scheduler_create_job_rec_handles_data_generation_without_has_output(tes
     for node in workflow_process_nodes:
         found_jobs = scheduler.find_new_jobs(node, manifest_map, new_jobs)
         new_jobs.extend(found_jobs)
+        #print(f"Found jobs for node {node.process}:")
+        #for job in found_jobs:
+            #print(f"Found job: {job.trigger_act.data_objects_by_type}")
 
     rqc_jobs = [j for j in new_jobs if j.workflow.type == "nmdc:ReadQcAnalysis"]
-    assert len(rqc_jobs) == 2
+    assert len(rqc_jobs) == 3 # one for metag1/metag2, one for access1, one for access2/access3
 
-    raw_read_job = next(j for j in rqc_jobs if j.trigger_id == "nmdc:omprc-11-metag1")
-    raw_read_job_req = scheduler.create_job_rec(raw_read_job, manifest_map)
-    assert "accessions" not in raw_read_job_req["config"]["inputs"]
+    accession_manifest_job = next(
+        j for j in rqc_jobs
+        if set(j.informed_by) == {"nmdc:dgns-11-access2", "nmdc:dgns-11-access3"}
+    )
+    accession_manifest_job_req = scheduler.create_job_rec(accession_manifest_job, manifest_map)
+    assert "accessions" in accession_manifest_job_req["config"]["inputs"]
+    assert len(accession_manifest_job_req["config"]["inputs"]["accessions"]) == 2
+    assert "input_fq1" not in accession_manifest_job_req["config"]["inputs"]
+    assert "input_fq2" not in accession_manifest_job_req["config"]["inputs"]
 
-    accession_job = next(j for j in rqc_jobs if j.trigger_id == "nmdc:omprc-11-metag2")
-    accession_job_req = scheduler.create_job_rec(accession_job, manifest_map)
-    assert accession_job_req["config"]["inputs"]["accessions"] == ["SRX123456", "SRX789012"]
-    assert "input_fq1" not in accession_job_req["config"]["inputs"]
-    assert "input_fq2" not in accession_job_req["config"]["inputs"]
+    single_accession_job = next(j for j in rqc_jobs if j.trigger_id == "nmdc:dgns-11-access1")
+    single_accession_job_req = scheduler.create_job_rec(single_accession_job, manifest_map)
+    assert "accessions" in single_accession_job_req["config"]["inputs"]
+    assert len(single_accession_job_req["config"]["inputs"]["accessions"]) == 1
+    assert "input_fq1" not in single_accession_job_req["config"]["inputs"]
+    assert "input_fq2" not in single_accession_job_req["config"]["inputs"]
+
+    dg_manifest_job = next(
+        j for j in rqc_jobs
+        if set(j.informed_by) == {"nmdc:omprc-11-metag1", "nmdc:omprc-11-metag2"}
+    )
+    dg_manifest_job_req = scheduler.create_job_rec(dg_manifest_job, manifest_map)
+    assert "accessions" not in dg_manifest_job_req["config"]["inputs"]
+    assert "input_fq1" in dg_manifest_job_req["config"]["inputs"]
+    assert "input_fq2" in dg_manifest_job_req["config"]["inputs"]
+
+
+    ## IM HERE: next need to add problem scenarios liek input_fq AND accessions
+    # also look at simplifying logic / making it more intuitive and less complicated
+
+    assert 1 == 2
+    '''
 
     metag3_record = test_db.data_generation_set.find_one({"id": "nmdc:omprc-11-metag3"})
     metag3_node = WorkflowProcessNode(metag3_record, raw_read_job.trigger_act.workflow)
     bad_job = SchedulerJob(raw_read_job.workflow, metag3_node, manifest_map)
     with pytest.raises(MissingDataObjectException):
         scheduler.create_job_rec(bad_job, manifest_map)
-
+    '''
 
 
 @pytest.mark.parametrize("job_fixture", [

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -387,7 +387,7 @@ def test_scheduler_create_job_rec_has_input_files_as_array(test_db, test_client,
     assert assembly["config"]["inputs"]["shortRead"] == True
     assert isinstance(assembly["config"]["inputs"]["input_files"], list)
 
-def test_scheduler_create_job_rec_handles_data_generation_without_has_output(test_db, test_client, workflows_config_dir, site_config_file):
+def test_scheduler_create_job_rec_do_sra(test_db, test_client, workflows_config_dir, site_config_file):
     """
     Test that data objects with accession ids successfully make input jsons
     """

--- a/tests/test_workflow_process.py
+++ b/tests/test_workflow_process.py
@@ -6,6 +6,7 @@ from nmdc_automation.workflow_automation.workflow_process import (
     load_workflow_process_nodes,
     _resolve_relationships,
     _map_nodes_to_data_objects,
+    _check,
     _within_range
 )
 from nmdc_automation.workflow_automation.workflows import load_workflow_configs
@@ -271,3 +272,24 @@ def test_within_range():
     assert _within_range('v1.0.8', 'v1.0.0')
     # Major version - out of range
     assert not _within_range('v1.0.8', 'v2.0.0')
+
+
+def test_check_accepts_sra_when_reads_are_required(test_db, test_client, workflows_config_dir):
+    """SRA-only input should satisfy workflows that otherwise expect paired raw reads."""
+    reset_db(test_db)
+    load_fixture(test_db, "data_object_set_accession.json", "data_object_set")
+
+    workflow_config = load_workflow_configs(workflows_config_dir / "workflows.yaml")
+    data_objects_by_id = get_required_data_objects_map(test_client, workflow_config)
+
+    sra_object_id = next(
+        doid
+        for doid, data_object in data_objects_by_id.items()
+        if data_object.data_object_type.code.text == "SRA toolkit-accessible sequence data"
+    )
+
+    assert _check(
+        ["Metagenome Raw Read 1", "Metagenome Raw Read 2"],
+        [sra_object_id],
+        data_objects_by_id,
+    )


### PR DESCRIPTION
Fixed SRA logic to address accessions being provided via data objects rather than data generation records:
- Added `SRA toolkit-accessible sequence data` to `Filter Input Objects` and `Inputs` in ReadsQC Interleave in `workflows.yaml`
- Added function `required_data_object_types_satisfied` to `workflow_process.py`, ensuring a list of input data object types from the `workflows.yaml` matches a list of data object types from the workflow processing node, with a new restriction for input data object types to either `Metagenome Raw Read 1 & 2` **_or_** `SRA toolkit-accessible sequence data`. This function is utilized in the watcher (`get_current_workflow_process_nodes`) and the scheduler (`create_job_rec`)
- Replaced previous code pulling accession ids from the data generation records with code pulling accession ids from the data objects

IMPORTANT NOTES:
- New code ONLY pulls accession ids via `insdc_run_identifiers` slot on data objects, even though they can technically exist other places (including `insdc_experiment_identifiers` on data object, and either of the aforementioned slots on data generation records)
- If there is more than one data object in a data generation's `has_output` and they are of the same type (ie more than one data object of type `SRA toolkit-accessible sequence data`), the code uses only the last listed object to create the job. More than one accession id can be linked via `in_manifest` (see example in `test_scheduler_create_job_rec_do_sra`). This is consistent with the existing code. IF there will be data generation records with more than one SRA data object, this will need to be adjusted. 