### PR TITLE
operations status update for max failed wf job attempts

### DIFF
--- a/nmdc_automation/workflow_automation/sched.py
+++ b/nmdc_automation/workflow_automation/sched.py
@@ -405,12 +405,19 @@ class Scheduler:
             # the assumption is that a job in any state has been triggered by an activity
             # that was the result of an existing (completed) job
             act = j["config"]["trigger_activity"]
-
-            if not manifest_id and j["config"].get("manifest"):
+            
+            # Get the current job's manifest value if available
+            j_manifest = j["config"].get("manifest")
+            
+            # When we don't have a manifest_id to filter jobs, then we want to warn if 
+            # manifest_id is not available for filter criteria (individual dg id) and we find
+            # a historical job that has manifest in its config
+            if not manifest_id and j_manifest:
                 logger.warning(
-                    f"Data integrity mismatch for activity {act}: Live data object is individual, "
-                    f"but historical job {j.get('id')} was run as part of manifest '{j['config']['manifest']}'. "
-                    f"Upstream database may have changed. Proceeding with individual scheduling."
+                    f"[Data Integrity Warning] manifest_set mismatch for '{act}' during existing jobs lookup. "
+                    f"Current job filtering: manifest_id=None. "
+                    f"Historical Job ID '{j.get('id')}': manifest_set: {j_manifest}. "
+                    f"Skipping this historical job from existing jobs evaluation."
                 )
                 continue
             

--- a/nmdc_automation/workflow_automation/watch_nmdc.py
+++ b/nmdc_automation/workflow_automation/watch_nmdc.py
@@ -129,7 +129,7 @@ class JobManager:
         self.file_handler = file_handler
         self.jaws_api = jaws_api
         self._job_cache = []
-        self._MAX_FAILS = 2
+        self._MAX_FAILS = 3
         if init_cache:
             self.restore_from_state()
 
@@ -299,19 +299,24 @@ class JobManager:
         self.save_checkpoint()
         return database
 
-    def process_failed_job(self, job: WorkflowJob) -> Optional[str]:
-        """ Process a failed job """
+    def process_failed_job(self, job: WorkflowJob) -> tuple[bool, Optional[str]]:
+        """ Process a failed job and determine if max retries are reached """
+        
+        job.workflow.state["failed_count"] = job.workflow.state.get("failed_count", 0) + 1
+        job.workflow.state["last_status"] = job.job_status
+
         if job.workflow.state.get("failed_count", 0) >= self._MAX_FAILS:
             logger.error(f"Job {job.opid} failed {self._MAX_FAILS} times. Skipping.")
             job.done = True
             self.save_checkpoint()
-            return None
-        job.workflow.state["failed_count"] = job.workflow.state.get("failed_count", 0) + 1
-        job.workflow.state["last_status"] = job.job_status
+            # Return boolean if max_failed is reached 
+            return True, None
+        
+        # Otherwise retry
         self.save_checkpoint()
         logger.warning(f"Job {job.opid} failed {job.workflow.state['failed_count']} times. Retrying.")
         jobid = job.job.submit_job()
-        return jobid
+        return False, jobid
 
     def report(self) -> List[dict]:
         """ Report the current state of the JobManager's job cache """
@@ -400,7 +405,7 @@ class Watcher:
     """ Watcher class for monitoring and managing jobs """
     def __init__(self, site_configuration_file: Union[str, Path],  state_file: Union[str, Path] = None, use_jaws: bool = False):
         self._POLL_INTERVAL_SEC = 600   # 10 minutes to avoid spamming the API
-        self._MAX_FAILS = 2
+        #self._MAX_FAILS = 3 (20260731 - slated for removal - unused as we use the one in JobManager)
         self.should_skip_claim = False
         self.config = SiteConfig(site_configuration_file)
         self.file_handler = FileHandler(self.config, state_file)
@@ -479,7 +484,15 @@ class Watcher:
 
         for job in failed_jobs:
             logger.info(f"Processing failed job: {job.opid}, {job.workflow_execution_id}")
-            self.job_manager.process_failed_job(job)
+            is_max_failed, new_jobid = self.job_manager.process_failed_job(job)
+            
+            if is_max_failed:
+                logger.info(f"Job op {job.opid} reached max retries. Unlocking operation record.")
+                # update the operation record
+                resp = self.runtime_api_handler.update_operation(
+                    job.opid, done=True, meta=job.job.metadata
+                )
+                logging.info(f"Updated operation {job.opid} response id: {resp['id']}")
 
     def watch(self):
         """ Maintain a polling loop to 'cycle' through job claims and processing """

--- a/tests/test_watch_nmdc.py
+++ b/tests/test_watch_nmdc.py
@@ -334,7 +334,7 @@ def test_job_manager_get_finished_jobs(site_config, initial_state_file_1_failure
             )
         # Mock the failed job status
         m.get(
-            "http://localhost:8088/api/workflows/v1/12345678-abcd-efgh-ijkl-9876543210/status",
+            "http://localhost:8088/api/workflows/v1/149426/status",
             json={"status": "Failed"}
             )
         # Mock for the manifest job
@@ -443,8 +443,10 @@ def test_job_manager_get_finished_jobs_1_failure(site_config, initial_state_file
         assert failed_job.job_status.lower() == "failed"
 
 @mock.patch("nmdc_automation.workflow_automation.wfutils.WorkflowStateManager.generate_submission_files")
-def test_job_manager_process_failed_job_1_failure(
-        mock_generate_submission_files, site_config, initial_state_file_1_failure, mock_cromwell_api):
+def test_job_manager_process_failed_job_1_failure(mock_generate_submission_files, site_config, initial_state_file_1_failure, mock_cromwell_api):
+    '''
+    This processes a failed job that already had one failed attempt (so it will increment the count and submit a new job attempt)
+    '''
     # Arrange
     mock_generate_submission_files.return_value = {
         "workflowSource": "workflowSource",
@@ -454,24 +456,36 @@ def test_job_manager_process_failed_job_1_failure(
     }
     fh = FileHandler(site_config, initial_state_file_1_failure)
     jm = JobManager(site_config, fh)
+
+    # Pin threshold for fixture alignment
+    # to ensure test continues to pass in case this constant in the code changes in the future
+    jm._MAX_FAILS = 3
+
     failed_job = jm.job_cache[0]
     # Act
-    jobid = jm.process_failed_job(failed_job)
-    assert jobid
-
+    is_max_failed, jobid = jm.process_failed_job(failed_job)
+    assert is_max_failed is False
+    assert jobid is not None
 
 
 def test_job_manager_process_failed_job_2_failures(site_config, initial_state_file_1_failure, fixtures_dir, mock_jaws_api):
     # Arrange
     fh = FileHandler(site_config, initial_state_file_1_failure)
     jm = JobManager(site_config, fh, jaws_api=mock_jaws_api)
+    
+    # Pin threshold for fixture alignment
+    # to ensure test continues to pass in case this constant in the code changes in the future
+    jm._MAX_FAILS = 3
+
     failed_job_state = json.load(open(fixtures_dir / "failed_job_state_2.json"))
     assert failed_job_state
     failed_job = WorkflowJob(site_config, failed_job_state, jaws_api=mock_jaws_api)
     jm.job_cache.append(failed_job)
     # Act
-    jm.process_failed_job(failed_job)
+    is_max_failed, jobid = jm.process_failed_job(failed_job)
     # Assert
+    assert is_max_failed is True
+    assert jobid is None
     assert failed_job.done
     assert failed_job.job_status.lower() == "failed"
 
@@ -698,6 +712,7 @@ def test_watcher_restore_from_checkpoint_and_report(site_config_file, fixtures_d
     assert rpt['wdl'] == "mbin_nmdc.wdl"
     assert rpt['last_status'] == "failed"
 
+
 @pytest.mark.parametrize("site_id, expected_resource", [
     ("nmdc", "NERSC-Perlmutter"),
     ("nmdc_tahoma", "EMSL-Tahoma"),
@@ -755,3 +770,48 @@ def test_watcher_validate_exec_resource_mapping(site_config, initial_state_file_
 
         # cleanup
         jm.job_cache = []
+
+
+def test_watcher_cycle_updates_ops_on_max_failures(site_config_file, site_config, initial_state_file_1_failure, fixtures_dir, mock_jaws_api):
+    '''
+    Test that watcher.cycle() sets operation done=True in the runtime API 
+    when a job reaches max failures. 
+    '''
+    # 1. Arrange - Set up FileHandler and JobManager
+    fh = FileHandler(site_config, initial_state_file_1_failure)
+    jm = JobManager(site_config, fh, jaws_api=mock_jaws_api)
+    
+    # Ensure threshold is fixed to 3 for this test to match static fixture data
+    jm._MAX_FAILS = 3
+
+    # Load the failed job state fixture with 2 failed attempts and last_status = failed
+    failed_job_state = json.load(open(fixtures_dir / "failed_job_state_2.json"))
+    failed_job = WorkflowJob(site_config, failed_job_state, jaws_api=mock_jaws_api)
+    
+    # Place job into the manager's cache
+    jm.job_cache = [failed_job]
+
+    # Initialize Watcher using site_config_file and initial state
+    w = Watcher(site_config_file, state_file=initial_state_file_1_failure)
+    w.job_manager = jm
+
+    # Mock Runtime API Handler methods to avoid real network/DB calls
+    w.runtime_api_handler.get_unclaimed_jobs = MagicMock(return_value=[])
+    w.claim_jobs = MagicMock()
+    w.restore_from_checkpoint = MagicMock()
+    w.runtime_api_handler.update_operation = MagicMock(return_value={"id": "mock_opid_123"})
+
+    # Mock status check so get_finished_jobs identifies the job as "failed"
+    with patch.object(failed_job.job, "get_job_status", return_value="failed"):
+        w.cycle()
+
+    # 3. Assert
+    # Verify update_operation was called on runtime_api_handler with done=True
+    w.runtime_api_handler.update_operation.assert_called_once_with(
+        failed_job.opid,
+        done=True,
+        meta=failed_job.job.metadata
+    )
+    
+    # Verify the local job in cache was marked as done
+    assert failed_job.done is True


### PR DESCRIPTION
updated warning in scheduler finding conflicting manifest/non-manifest jobs
updated watcher to update operations collection when job failed status hits max retries
bug fix some failure retry count logic and corresponding pytests